### PR TITLE
feat(dashboard): resizable grid in the editor (API + drag handles + live preview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # See https://docs.github.com/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
+.agents
+.claude
 CLAUDE.md
 prompts
-.claude
+skills-lock.json
 
 # Compiled output
 /dist

--- a/projects/demo/src/locale/messages.de.xlf
+++ b/projects/demo/src/locale/messages.de.xlf
@@ -21,8 +21,8 @@
     </unit>
     <unit id="demo.app.title">
       <segment state="initial">
-        <source>Dashboard Demo and Component Tests</source>
-        <target>Dashboard Demo and Component Tests</target>
+        <source>Dashboard Demo</source>
+        <target>Dashboard Demo</target>
       </segment>
     </unit>
     <unit id="demo.theme.switchToLight">
@@ -85,6 +85,18 @@
         <target>Color preview for <ph id="0" equiv="INTERPOLATION" disp="colorName"/></target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.exitedZoom">
+      <segment state="initial">
+        <source>Returned to full dashboard</source>
+        <target>Returned to full dashboard</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.exitZoomEsc">
+      <segment state="initial">
+        <source>Exit Zoom (ESC)</source>
+        <target>Exit Zoom (ESC)</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.exportToFile">
       <segment state="initial">
         <source>Export to File</source>
@@ -103,6 +115,18 @@
         <target>Save to Browser</target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.selectArea">
+      <segment state="initial">
+        <source>Zoom to Area</source>
+        <target>Zoom to Area</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.selectionModeInstructions">
+      <segment state="initial">
+        <source>Drag to select area • Press ESC to cancel</source>
+        <target>Drag to select area • Press ESC to cancel</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.loadFromBrowser">
       <segment state="initial">
         <source>Load from Browser</source>
@@ -113,6 +137,18 @@
       <segment state="initial">
         <source>Reset to Default</source>
         <target>Reset to Default</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelect">
+      <segment state="initial">
+        <source>Cancel Zoom</source>
+        <target>Cancel Zoom</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelectionEsc">
+      <segment state="initial">
+        <source>Cancel Selection (ESC)</source>
+        <target>Cancel Selection (ESC)</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.clearDashboard">
@@ -131,6 +167,30 @@
       <segment state="initial">
         <source>Switch to View Mode</source>
         <target>Switch to View Mode</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.widgetsTitle">
+      <segment state="initial">
+        <source>Widgets</source>
+        <target>Widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomModeActive">
+      <segment state="initial">
+        <source>Zoom Mode Active</source>
+        <target>Zoom Mode Active</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomToSelection">
+      <segment state="initial">
+        <source>Zoom to Selection</source>
+        <target>Zoom to Selection</target>
+      </segment>
+    </unit>
+    <unit id="demo.github.viewOnGitHub">
+      <segment state="initial">
+        <source>View source code on GitHub</source>
+        <target>View source code on GitHub</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.switchToEditMode">
@@ -1081,6 +1141,132 @@
         <target>Sparkline</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.temperature.description">
+      <segment state="initial">
+        <source>Display a temperature value</source>
+        <target>Display a temperature value</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.background">
+      <segment state="initial">
+        <source> Background </source>
+        <target> Background </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.backgroundDescription">
+      <segment state="initial">
+        <source>Adds a background behind the temperature</source>
+        <target>Adds a background behind the temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.label">
+      <segment state="initial">
+        <source>Label (optional)</source>
+        <target>Label (optional)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.labelPlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnit">
+      <segment state="initial">
+        <source>Shared Unit</source>
+        <target>Shared Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnitHint">
+      <segment state="initial">
+        <source>This unit is shared across all temperature widgets</source>
+        <target>This unit is shared across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureHint">
+      <segment state="initial">
+        <source>Value stored in Celsius and converted for display</source>
+        <target>Value stored in Celsius and converted for display</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValue">
+      <segment state="initial">
+        <source>Temperature Value (°C)</source>
+        <target>Temperature Value (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValuePlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.title">
+      <segment state="initial">
+        <source> Temperature Settings </source>
+        <target> Temperature Settings </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unit">
+      <segment state="initial">
+        <source>Temperature Unit</source>
+        <target>Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitCelsius">
+      <segment state="initial">
+        <source>Celsius (°C)</source>
+        <target>Celsius (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitFahrenheit">
+      <segment state="initial">
+        <source>Fahrenheit (°F)</source>
+        <target>Fahrenheit (°F)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitKelvin">
+      <segment state="initial">
+        <source>Kelvin (K)</source>
+        <target>Kelvin (K)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnit">
+      <segment state="initial">
+        <source> Use shared unit </source>
+        <target> Use shared unit </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnitDescription">
+      <segment state="initial">
+        <source>Use the same unit across all temperature widgets</source>
+        <target>Use the same unit across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.name">
+      <segment state="initial">
+        <source>Temperature</source>
+        <target>Temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.defaultUnit">
+      <segment state="initial">
+        <source>Default Temperature Unit</source>
+        <target>Default Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.description">
+      <segment state="initial">
+        <source> These settings apply to all temperature widgets that use shared unit. </source>
+        <target> These settings apply to all temperature widgets that use shared unit. </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.title">
+      <segment state="initial">
+        <source> Shared Temperature Settings </source>
+        <target> Shared Temperature Settings </target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.sparkline.description">
       <segment state="initial">
         <source>A sparkline graph</source>
@@ -1151,6 +1337,18 @@
       <segment state="initial">
         <source> Save </source>
         <target> Save </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.editor.gridResize.dimensions">
+      <segment state="initial">
+        <source> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </source>
+        <target> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.emptyCellMenu.noWidgets">
+      <segment state="initial">
+        <source>No widgets available</source>
+        <target>No widgets available</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.name">
@@ -1517,6 +1715,12 @@
       <segment state="initial">
         <source>Edit Widget</source>
         <target>Edit Widget</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.cell.menu.editShared">
+      <segment state="initial">
+        <source>Edit Shared State</source>
+        <target>Edit Shared State</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.cell.menu.settings">

--- a/projects/demo/src/locale/messages.es.xlf
+++ b/projects/demo/src/locale/messages.es.xlf
@@ -21,8 +21,8 @@
     </unit>
     <unit id="demo.app.title">
       <segment state="initial">
-        <source>Dashboard Demo and Component Tests</source>
-        <target>Dashboard Demo and Component Tests</target>
+        <source>Dashboard Demo</source>
+        <target>Dashboard Demo</target>
       </segment>
     </unit>
     <unit id="demo.theme.switchToLight">
@@ -85,6 +85,18 @@
         <target>Color preview for <ph id="0" equiv="INTERPOLATION" disp="colorName"/></target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.exitedZoom">
+      <segment state="initial">
+        <source>Returned to full dashboard</source>
+        <target>Returned to full dashboard</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.exitZoomEsc">
+      <segment state="initial">
+        <source>Exit Zoom (ESC)</source>
+        <target>Exit Zoom (ESC)</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.exportToFile">
       <segment state="initial">
         <source>Export to File</source>
@@ -103,6 +115,18 @@
         <target>Save to Browser</target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.selectArea">
+      <segment state="initial">
+        <source>Zoom to Area</source>
+        <target>Zoom to Area</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.selectionModeInstructions">
+      <segment state="initial">
+        <source>Drag to select area • Press ESC to cancel</source>
+        <target>Drag to select area • Press ESC to cancel</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.loadFromBrowser">
       <segment state="initial">
         <source>Load from Browser</source>
@@ -113,6 +137,18 @@
       <segment state="initial">
         <source>Reset to Default</source>
         <target>Reset to Default</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelect">
+      <segment state="initial">
+        <source>Cancel Zoom</source>
+        <target>Cancel Zoom</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelectionEsc">
+      <segment state="initial">
+        <source>Cancel Selection (ESC)</source>
+        <target>Cancel Selection (ESC)</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.clearDashboard">
@@ -131,6 +167,30 @@
       <segment state="initial">
         <source>Switch to View Mode</source>
         <target>Switch to View Mode</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.widgetsTitle">
+      <segment state="initial">
+        <source>Widgets</source>
+        <target>Widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomModeActive">
+      <segment state="initial">
+        <source>Zoom Mode Active</source>
+        <target>Zoom Mode Active</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomToSelection">
+      <segment state="initial">
+        <source>Zoom to Selection</source>
+        <target>Zoom to Selection</target>
+      </segment>
+    </unit>
+    <unit id="demo.github.viewOnGitHub">
+      <segment state="initial">
+        <source>View source code on GitHub</source>
+        <target>View source code on GitHub</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.switchToEditMode">
@@ -1081,6 +1141,132 @@
         <target>Sparkline</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.temperature.description">
+      <segment state="initial">
+        <source>Display a temperature value</source>
+        <target>Display a temperature value</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.background">
+      <segment state="initial">
+        <source> Background </source>
+        <target> Background </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.backgroundDescription">
+      <segment state="initial">
+        <source>Adds a background behind the temperature</source>
+        <target>Adds a background behind the temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.label">
+      <segment state="initial">
+        <source>Label (optional)</source>
+        <target>Label (optional)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.labelPlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnit">
+      <segment state="initial">
+        <source>Shared Unit</source>
+        <target>Shared Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnitHint">
+      <segment state="initial">
+        <source>This unit is shared across all temperature widgets</source>
+        <target>This unit is shared across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureHint">
+      <segment state="initial">
+        <source>Value stored in Celsius and converted for display</source>
+        <target>Value stored in Celsius and converted for display</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValue">
+      <segment state="initial">
+        <source>Temperature Value (°C)</source>
+        <target>Temperature Value (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValuePlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.title">
+      <segment state="initial">
+        <source> Temperature Settings </source>
+        <target> Temperature Settings </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unit">
+      <segment state="initial">
+        <source>Temperature Unit</source>
+        <target>Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitCelsius">
+      <segment state="initial">
+        <source>Celsius (°C)</source>
+        <target>Celsius (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitFahrenheit">
+      <segment state="initial">
+        <source>Fahrenheit (°F)</source>
+        <target>Fahrenheit (°F)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitKelvin">
+      <segment state="initial">
+        <source>Kelvin (K)</source>
+        <target>Kelvin (K)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnit">
+      <segment state="initial">
+        <source> Use shared unit </source>
+        <target> Use shared unit </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnitDescription">
+      <segment state="initial">
+        <source>Use the same unit across all temperature widgets</source>
+        <target>Use the same unit across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.name">
+      <segment state="initial">
+        <source>Temperature</source>
+        <target>Temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.defaultUnit">
+      <segment state="initial">
+        <source>Default Temperature Unit</source>
+        <target>Default Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.description">
+      <segment state="initial">
+        <source> These settings apply to all temperature widgets that use shared unit. </source>
+        <target> These settings apply to all temperature widgets that use shared unit. </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.title">
+      <segment state="initial">
+        <source> Shared Temperature Settings </source>
+        <target> Shared Temperature Settings </target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.sparkline.description">
       <segment state="initial">
         <source>A sparkline graph</source>
@@ -1151,6 +1337,18 @@
       <segment state="initial">
         <source> Save </source>
         <target> Save </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.editor.gridResize.dimensions">
+      <segment state="initial">
+        <source> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </source>
+        <target> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.emptyCellMenu.noWidgets">
+      <segment state="initial">
+        <source>No widgets available</source>
+        <target>No widgets available</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.name">
@@ -1517,6 +1715,12 @@
       <segment state="initial">
         <source>Edit Widget</source>
         <target>Edit Widget</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.cell.menu.editShared">
+      <segment state="initial">
+        <source>Edit Shared State</source>
+        <target>Edit Shared State</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.cell.menu.settings">

--- a/projects/demo/src/locale/messages.fr.xlf
+++ b/projects/demo/src/locale/messages.fr.xlf
@@ -21,8 +21,8 @@
     </unit>
     <unit id="demo.app.title">
       <segment state="initial">
-        <source>Dashboard Demo and Component Tests</source>
-        <target>Dashboard Demo and Component Tests</target>
+        <source>Dashboard Demo</source>
+        <target>Dashboard Demo</target>
       </segment>
     </unit>
     <unit id="demo.theme.switchToLight">
@@ -85,6 +85,18 @@
         <target>Color preview for <ph id="0" equiv="INTERPOLATION" disp="colorName"/></target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.exitedZoom">
+      <segment state="initial">
+        <source>Returned to full dashboard</source>
+        <target>Returned to full dashboard</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.exitZoomEsc">
+      <segment state="initial">
+        <source>Exit Zoom (ESC)</source>
+        <target>Exit Zoom (ESC)</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.exportToFile">
       <segment state="initial">
         <source>Export to File</source>
@@ -103,6 +115,18 @@
         <target>Save to Browser</target>
       </segment>
     </unit>
+    <unit id="demo.dashboard.selectArea">
+      <segment state="initial">
+        <source>Zoom to Area</source>
+        <target>Zoom to Area</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.selectionModeInstructions">
+      <segment state="initial">
+        <source>Drag to select area • Press ESC to cancel</source>
+        <target>Drag to select area • Press ESC to cancel</target>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.loadFromBrowser">
       <segment state="initial">
         <source>Load from Browser</source>
@@ -113,6 +137,18 @@
       <segment state="initial">
         <source>Reset to Default</source>
         <target>Reset to Default</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelect">
+      <segment state="initial">
+        <source>Cancel Zoom</source>
+        <target>Cancel Zoom</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelectionEsc">
+      <segment state="initial">
+        <source>Cancel Selection (ESC)</source>
+        <target>Cancel Selection (ESC)</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.clearDashboard">
@@ -131,6 +167,30 @@
       <segment state="initial">
         <source>Switch to View Mode</source>
         <target>Switch to View Mode</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.widgetsTitle">
+      <segment state="initial">
+        <source>Widgets</source>
+        <target>Widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomModeActive">
+      <segment state="initial">
+        <source>Zoom Mode Active</source>
+        <target>Zoom Mode Active</target>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomToSelection">
+      <segment state="initial">
+        <source>Zoom to Selection</source>
+        <target>Zoom to Selection</target>
+      </segment>
+    </unit>
+    <unit id="demo.github.viewOnGitHub">
+      <segment state="initial">
+        <source>View source code on GitHub</source>
+        <target>View source code on GitHub</target>
       </segment>
     </unit>
     <unit id="demo.dashboard.switchToEditMode">
@@ -1081,6 +1141,132 @@
         <target>Sparkline</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.temperature.description">
+      <segment state="initial">
+        <source>Display a temperature value</source>
+        <target>Display a temperature value</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.background">
+      <segment state="initial">
+        <source> Background </source>
+        <target> Background </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.backgroundDescription">
+      <segment state="initial">
+        <source>Adds a background behind the temperature</source>
+        <target>Adds a background behind the temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.label">
+      <segment state="initial">
+        <source>Label (optional)</source>
+        <target>Label (optional)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.labelPlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnit">
+      <segment state="initial">
+        <source>Shared Unit</source>
+        <target>Shared Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnitHint">
+      <segment state="initial">
+        <source>This unit is shared across all temperature widgets</source>
+        <target>This unit is shared across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureHint">
+      <segment state="initial">
+        <source>Value stored in Celsius and converted for display</source>
+        <target>Value stored in Celsius and converted for display</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValue">
+      <segment state="initial">
+        <source>Temperature Value (°C)</source>
+        <target>Temperature Value (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValuePlaceholder">
+      <segment state="initial">
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></source>
+        <target><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.title">
+      <segment state="initial">
+        <source> Temperature Settings </source>
+        <target> Temperature Settings </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unit">
+      <segment state="initial">
+        <source>Temperature Unit</source>
+        <target>Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitCelsius">
+      <segment state="initial">
+        <source>Celsius (°C)</source>
+        <target>Celsius (°C)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitFahrenheit">
+      <segment state="initial">
+        <source>Fahrenheit (°F)</source>
+        <target>Fahrenheit (°F)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitKelvin">
+      <segment state="initial">
+        <source>Kelvin (K)</source>
+        <target>Kelvin (K)</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnit">
+      <segment state="initial">
+        <source> Use shared unit </source>
+        <target> Use shared unit </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnitDescription">
+      <segment state="initial">
+        <source>Use the same unit across all temperature widgets</source>
+        <target>Use the same unit across all temperature widgets</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.name">
+      <segment state="initial">
+        <source>Temperature</source>
+        <target>Temperature</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.defaultUnit">
+      <segment state="initial">
+        <source>Default Temperature Unit</source>
+        <target>Default Temperature Unit</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.description">
+      <segment state="initial">
+        <source> These settings apply to all temperature widgets that use shared unit. </source>
+        <target> These settings apply to all temperature widgets that use shared unit. </target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.title">
+      <segment state="initial">
+        <source> Shared Temperature Settings </source>
+        <target> Shared Temperature Settings </target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.sparkline.description">
       <segment state="initial">
         <source>A sparkline graph</source>
@@ -1151,6 +1337,18 @@
       <segment state="initial">
         <source> Save </source>
         <target> Save </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.editor.gridResize.dimensions">
+      <segment state="initial">
+        <source> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </source>
+        <target> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.emptyCellMenu.noWidgets">
+      <segment state="initial">
+        <source>No widgets available</source>
+        <target>No widgets available</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.name">
@@ -1517,6 +1715,12 @@
       <segment state="initial">
         <source>Edit Widget</source>
         <target>Edit Widget</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.cell.menu.editShared">
+      <segment state="initial">
+        <source>Edit Shared State</source>
+        <target>Edit Shared State</target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.cell.menu.settings">

--- a/projects/demo/src/locale/messages.xlf
+++ b/projects/demo/src/locale/messages.xlf
@@ -18,7 +18,7 @@
     </unit>
     <unit id="demo.app.title">
       <segment>
-        <source>Dashboard Demo and Component Tests</source>
+        <source>Dashboard Demo</source>
       </segment>
     </unit>
     <unit id="demo.theme.switchToLight">
@@ -71,6 +71,16 @@
         <source>Color preview for <ph id="0" equiv="INTERPOLATION" disp="colorName"/></source>
       </segment>
     </unit>
+    <unit id="demo.dashboard.exitedZoom">
+      <segment>
+        <source>Returned to full dashboard</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.exitZoomEsc">
+      <segment>
+        <source>Exit Zoom (ESC)</source>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.exportToFile">
       <segment>
         <source>Export to File</source>
@@ -86,6 +96,16 @@
         <source>Save to Browser</source>
       </segment>
     </unit>
+    <unit id="demo.dashboard.selectArea">
+      <segment>
+        <source>Zoom to Area</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.selectionModeInstructions">
+      <segment>
+        <source>Drag to select area • Press ESC to cancel</source>
+      </segment>
+    </unit>
     <unit id="demo.dashboard.loadFromBrowser">
       <segment>
         <source>Load from Browser</source>
@@ -94,6 +114,16 @@
     <unit id="demo.dashboard.resetToDefault">
       <segment>
         <source>Reset to Default</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelect">
+      <segment>
+        <source>Cancel Zoom</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.cancelSelectionEsc">
+      <segment>
+        <source>Cancel Selection (ESC)</source>
       </segment>
     </unit>
     <unit id="demo.dashboard.clearDashboard">
@@ -109,6 +139,26 @@
     <unit id="demo.dashboard.switchToViewMode">
       <segment>
         <source>Switch to View Mode</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.widgetsTitle">
+      <segment>
+        <source>Widgets</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomModeActive">
+      <segment>
+        <source>Zoom Mode Active</source>
+      </segment>
+    </unit>
+    <unit id="demo.dashboard.zoomToSelection">
+      <segment>
+        <source>Zoom to Selection</source>
+      </segment>
+    </unit>
+    <unit id="demo.github.viewOnGitHub">
+      <segment>
+        <source>View source code on GitHub</source>
       </segment>
     </unit>
     <unit id="demo.dashboard.switchToEditMode">
@@ -901,6 +951,111 @@
         <source>Sparkline</source>
       </segment>
     </unit>
+    <unit id="demo.widgets.temperature.description">
+      <segment>
+        <source>Display a temperature value</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.background">
+      <segment>
+        <source> Background </source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.backgroundDescription">
+      <segment>
+        <source>Adds a background behind the temperature</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.label">
+      <segment>
+        <source>Label (optional)</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.labelPlaceholder">
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ labelPlaceholder }}"/></source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnit">
+      <segment>
+        <source>Shared Unit</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.sharedUnitHint">
+      <segment>
+        <source>This unit is shared across all temperature widgets</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureHint">
+      <segment>
+        <source>Value stored in Celsius and converted for display</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValue">
+      <segment>
+        <source>Temperature Value (°C)</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.temperatureValuePlaceholder">
+      <segment>
+        <source><ph id="0" equiv="INTERPOLATION" disp="{{ temperaturePlaceholder }}"/></source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.title">
+      <segment>
+        <source> Temperature Settings </source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unit">
+      <segment>
+        <source>Temperature Unit</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitCelsius">
+      <segment>
+        <source>Celsius (°C)</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitFahrenheit">
+      <segment>
+        <source>Fahrenheit (°F)</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.unitKelvin">
+      <segment>
+        <source>Kelvin (K)</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnit">
+      <segment>
+        <source> Use shared unit </source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.dialog.useSharedUnitDescription">
+      <segment>
+        <source>Use the same unit across all temperature widgets</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.name">
+      <segment>
+        <source>Temperature</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.defaultUnit">
+      <segment>
+        <source>Default Temperature Unit</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.description">
+      <segment>
+        <source> These settings apply to all temperature widgets that use shared unit. </source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.temperature.sharedDialog.title">
+      <segment>
+        <source> Shared Temperature Settings </source>
+      </segment>
+    </unit>
     <unit id="demo.widgets.sparkline.description">
       <segment>
         <source>A sparkline graph</source>
@@ -959,6 +1114,16 @@
     <unit id="ngx.dashboard.common.save">
       <segment>
         <source> Save </source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.editor.gridResize.dimensions">
+      <segment>
+        <source> <ph id="0" equiv="INTERPOLATION"/> × <ph id="1" equiv="INTERPOLATION_1"/> </source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.emptyCellMenu.noWidgets">
+      <segment>
+        <source>No widgets available</source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.name">
@@ -1264,6 +1429,11 @@
     <unit id="ngx.dashboard.cell.menu.edit">
       <segment>
         <source>Edit Widget</source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.cell.menu.editShared">
+      <segment>
+        <source>Edit Shared State</source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.cell.menu.settings">

--- a/projects/ngx-dashboard-widgets/package.json
+++ b/projects/ngx-dashboard-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dragonworks/ngx-dashboard-widgets",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Widget collection for ngx-dashboard with Material Design 3 compliance including arrow, label, clock widgets and responsive text directive",
   "publishConfig": {
     "access": "public"

--- a/projects/ngx-dashboard/package.json
+++ b/projects/ngx-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dragonworks/ngx-dashboard",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Angular library for building drag-and-drop grid dashboards with resizable cells and customizable widgets",
   "publishConfig": {
     "access": "public"

--- a/projects/ngx-dashboard/src/lib/cell/cell.component.scss
+++ b/projects/ngx-dashboard/src/lib/cell/cell.component.scss
@@ -1,4 +1,5 @@
 // cell.component.sccs
+@use "../styles/resize-cursors";
 
 :host {
   display: block;
@@ -191,14 +192,5 @@
   }
 }
 
-// Global cursor classes for resize operations
-// These are applied to document.body to ensure cursor shows everywhere during resize
-:root {
-  .cursor-col-resize {
-    cursor: col-resize !important;
-  }
-
-  .cursor-row-resize {
-    cursor: row-resize !important;
-  }
-}
+// Global body cursor classes for resize operations live in the shared
+// styles/_resize-cursors.scss partial (@use'd above).

--- a/projects/ngx-dashboard/src/lib/cell/cell.component.ts
+++ b/projects/ngx-dashboard/src/lib/cell/cell.component.ts
@@ -118,7 +118,7 @@ export class CellComponent {
       : false;
   });
 
-  isDragActive = computed(() => !!this.#store.dragData());
+  isDragActive = this.#store.isDragActive;
 
   resizeData = this.#store.resizeData;
   gridCellDimensions = this.#store.gridCellDimensions;

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
@@ -24,6 +24,29 @@
     }
   </div>
 
+  <!-- Grid resize handles (right edge, bottom edge, bottom-right corner).
+       Hidden during a widget drag to avoid conflicting gestures. -->
+  @if (!isDragActive()) {
+  <lib-grid-resize-handle
+    axis="horizontal"
+    [cellWidth]="cellDimensions().width"
+    [cellHeight]="cellDimensions().height"
+    (resizeEnd)="onGridResizeEnd($event)"
+  ></lib-grid-resize-handle>
+  <lib-grid-resize-handle
+    axis="vertical"
+    [cellWidth]="cellDimensions().width"
+    [cellHeight]="cellDimensions().height"
+    (resizeEnd)="onGridResizeEnd($event)"
+  ></lib-grid-resize-handle>
+  <lib-grid-resize-handle
+    axis="both"
+    [cellWidth]="cellDimensions().width"
+    [cellHeight]="cellDimensions().height"
+    (resizeEnd)="onGridResizeEnd($event)"
+  ></lib-grid-resize-handle>
+  }
+
   <!-- Top grid with interactive cells -->
   <div class="grid" id="top-grid">
     @for (cell of cells(); track cell.widgetId) {

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
@@ -15,6 +15,7 @@
       [highlightResize]="
         resizePreviewMap().has(createCellId(position.row, position.col))
       "
+      [highlightPreview]="isPreviewAdded(position.row, position.col)"
       [editMode]="true"
       (dragEnter)="onDragEnter($event)"
       (dragExit)="onDragExit()"
@@ -32,9 +33,21 @@
     [axis]="axis"
     [cellWidth]="cellDimensions().width"
     [cellHeight]="cellDimensions().height"
+    (resizeMove)="onGridResizeMove($event)"
     (resizeEnd)="onGridResizeEnd($event)"
   ></lib-grid-resize-handle>
   }
+  }
+
+  <!-- Live size badge shown while a resize handle is being dragged. -->
+  @if (gridResizePreview(); as preview) {
+  <div
+    class="grid-resize-badge"
+    [class.grid-resize-badge--clamped]="preview.clamped"
+    i18n="@@ngx.dashboard.editor.gridResize.dimensions"
+  >
+    {{ effectiveColumns() }} × {{ effectiveRows() }}
+  </div>
   }
 
   <!-- Top grid with interactive cells -->

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
@@ -46,7 +46,7 @@
     [class.grid-resize-badge--clamped]="preview.clamped"
     i18n="@@ngx.dashboard.editor.gridResize.dimensions"
   >
-    {{ effectiveColumns() }} × {{ effectiveRows() }}
+    {{ preview.columns }} × {{ preview.rows }}
   </div>
   }
 

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.html
@@ -27,24 +27,14 @@
   <!-- Grid resize handles (right edge, bottom edge, bottom-right corner).
        Hidden during a widget drag to avoid conflicting gestures. -->
   @if (!isDragActive()) {
+  @for (axis of resizeAxes; track axis) {
   <lib-grid-resize-handle
-    axis="horizontal"
+    [axis]="axis"
     [cellWidth]="cellDimensions().width"
     [cellHeight]="cellDimensions().height"
     (resizeEnd)="onGridResizeEnd($event)"
   ></lib-grid-resize-handle>
-  <lib-grid-resize-handle
-    axis="vertical"
-    [cellWidth]="cellDimensions().width"
-    [cellHeight]="cellDimensions().height"
-    (resizeEnd)="onGridResizeEnd($event)"
-  ></lib-grid-resize-handle>
-  <lib-grid-resize-handle
-    axis="both"
-    [cellWidth]="cellDimensions().width"
-    [cellHeight]="cellDimensions().height"
-    (resizeEnd)="onGridResizeEnd($event)"
-  ></lib-grid-resize-handle>
+  }
   }
 
   <!-- Top grid with interactive cells -->

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.scss
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.scss
@@ -85,3 +85,28 @@
   pointer-events: none; /* don’t block drop zones while lifted */
   opacity: 0.5;
 }
+
+/* ── Grid resize preview badge ───────────────────────────────────── */
+.grid-resize-badge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 30;
+
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  pointer-events: none;
+
+  background-color: var(--mat-sys-primary);
+  color: var(--mat-sys-on-primary);
+
+  /* When the requested shrink was clamped to the content floor, signal that
+     the grid can't get any smaller in that direction. */
+  &--clamped {
+    background-color: var(--mat-sys-error);
+    color: var(--mat-sys-on-error);
+  }
+}

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -21,6 +21,7 @@ import { DropZoneComponent } from '../drop-zone/drop-zone.component';
 import { EmptyCellContextMenuComponent } from '../drop-zone/empty-cell-context-menu.component';
 import {
   GridResizeHandleComponent,
+  GridResizeAxis,
   GridResizeDelta,
 } from '../grid-resize-handle/grid-resize-handle.component';
 import {
@@ -85,7 +86,14 @@ export class DashboardEditorComponent {
 
   // Hide grid resize handles while a widget drag is in progress to avoid
   // conflicting gestures.
-  isDragActive = computed(() => !!this.#store.dragData());
+  isDragActive = this.#store.isDragActive;
+
+  // Axes rendered as grid resize handles (right edge, bottom edge, corner).
+  protected readonly resizeAxes: GridResizeAxis[] = [
+    'horizontal',
+    'vertical',
+    'both',
+  ];
 
   // Generate all possible cell positions for the grid
   dropzonePositions = computed(() => {
@@ -211,15 +219,13 @@ export class DashboardEditorComponent {
     // Note: Store handles all validation and error handling internally
   }
 
-  // Commit a grid resize gesture: add the track-count delta to the current
-  // dimensions. The store clamps to content (shrink can't orphan widgets).
+  // Commit a grid resize gesture by the track-count delta. The store reads the
+  // current size as the base and clamps to content (shrink can't orphan widgets).
   onGridResizeEnd(delta: GridResizeDelta): void {
     if (delta.deltaColumns === 0 && delta.deltaRows === 0) return;
 
-    const result = this.#store.setGridSize(
-      this.#store.rows() + delta.deltaRows,
-      this.#store.columns() + delta.deltaColumns
+    this.gridResized.emit(
+      this.#store.growGrid(delta.deltaRows, delta.deltaColumns)
     );
-    this.gridResized.emit(result);
   }
 }

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -155,6 +155,11 @@ export class DashboardEditorComponent {
     effect(() => {
       this.#store.setEditMode(true);
     });
+
+    // Drop any in-progress resize preview if the editor is torn down mid-drag
+    // (e.g. editMode toggled off): the store outlives this component, so a
+    // stale preview would otherwise render a phantom grid on the next mount.
+    this.#destroyRef.onDestroy(() => this.#store.clearGridResizePreview());
   }
 
   #observeGridSize(): void {

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -51,8 +51,8 @@ import { DashboardStore } from '../store/dashboard-store';
   templateUrl: './dashboard-editor.component.html',
   styleUrl: './dashboard-editor.component.scss',
   host: {
-    '[style.--rows]': 'rows()',
-    '[style.--columns]': 'columns()',
+    '[style.--rows]': 'effectiveRows()',
+    '[style.--columns]': 'effectiveColumns()',
     '[style.--gutter-size]': 'gutterSize()',
     '[style.--gutters]': 'gutters()',
     '[class.is-edit-mode]': 'true', // Always in edit mode
@@ -70,7 +70,6 @@ export class DashboardEditorComponent {
   rows = input.required<number>();
   columns = input.required<number>();
   gutterSize = input<string>('1em');
-  gutters = computed(() => this.columns() + 1);
 
   // Emitted when a grid resize handle commits a new size (after clamp-to-content).
   gridResized = output<GridResizeResult>();
@@ -83,6 +82,16 @@ export class DashboardEditorComponent {
   hoveredDropZone = this.#store.hoveredDropZone;
   resizePreviewMap = this.#store.resizePreviewMap;
   cellDimensions = this.#store.gridCellDimensions;
+  gridResizePreview = this.#store.gridResizePreview;
+
+  // Effective grid size = the live drag preview when one is active, otherwise
+  // the committed size. Drives the grid template, aspect-ratio and drop zones
+  // so the editor reflows under the handle without committing.
+  effectiveRows = computed(() => this.gridResizePreview()?.rows ?? this.rows());
+  effectiveColumns = computed(
+    () => this.gridResizePreview()?.columns ?? this.columns()
+  );
+  gutters = computed(() => this.effectiveColumns() + 1);
 
   // Hide grid resize handles while a widget drag is in progress to avoid
   // conflicting gestures.
@@ -95,21 +104,33 @@ export class DashboardEditorComponent {
     'both',
   ];
 
-  // Generate all possible cell positions for the grid
+  // Generate all possible cell positions for the grid (using the effective
+  // size so the drop-zone grid grows/shrinks with the live resize preview).
   dropzonePositions = computed(() => {
+    const rows = this.effectiveRows();
+    const columns = this.effectiveColumns();
     const positions = [];
-    for (let row = 1; row <= this.rows(); row++) {
-      for (let col = 1; col <= this.columns(); col++) {
+    for (let row = 1; row <= rows; row++) {
+      for (let col = 1; col <= columns; col++) {
         positions.push({
           row,
           col,
           id: `dropzone-${row}-${col}`,
-          index: (row - 1) * this.columns() + col,
+          index: (row - 1) * columns + col,
         });
       }
     }
     return positions;
   });
+
+  // True for drop zones in the about-to-be-added region during a grow preview,
+  // so the template can tint the tracks the resize is adding.
+  isPreviewAdded(row: number, col: number): boolean {
+    return (
+      this.gridResizePreview() !== null &&
+      (row > this.rows() || col > this.columns())
+    );
+  }
 
   // Helper method for template
   createCellId(row: number, col: number): CellId {
@@ -219,9 +240,17 @@ export class DashboardEditorComponent {
     // Note: Store handles all validation and error handling internally
   }
 
-  // Commit a grid resize gesture by the track-count delta. The store reads the
-  // current size as the base and clamps to content (shrink can't orphan widgets).
+  // Live preview while dragging a handle: the store reflows the grid to the
+  // clamped target size without committing.
+  onGridResizeMove(delta: GridResizeDelta): void {
+    this.#store.previewGridResize(delta.deltaRows, delta.deltaColumns);
+  }
+
+  // Commit a grid resize gesture by the track-count delta. Always clears the
+  // preview first; the store reads the current size as the base and clamps to
+  // content (shrink can't orphan widgets).
   onGridResizeEnd(delta: GridResizeDelta): void {
+    this.#store.clearGridResizePreview();
     if (delta.deltaColumns === 0 && delta.deltaRows === 0) return;
 
     this.gridResized.emit(

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -54,7 +54,7 @@ import { DashboardStore } from '../store/dashboard-store';
     '[style.--rows]': 'effectiveRows()',
     '[style.--columns]': 'effectiveColumns()',
     '[style.--gutter-size]': 'gutterSize()',
-    '[style.--gutters]': 'gutters()',
+    '[style.--gutters]': 'effectiveColumns() + 1',
     '[class.is-edit-mode]': 'true', // Always in edit mode
   },
 })
@@ -91,7 +91,6 @@ export class DashboardEditorComponent {
   effectiveColumns = computed(
     () => this.gridResizePreview()?.columns ?? this.columns()
   );
-  gutters = computed(() => this.effectiveColumns() + 1);
 
   // Hide grid resize handles while a widget drag is in progress to avoid
   // conflicting gestures.
@@ -246,15 +245,13 @@ export class DashboardEditorComponent {
     this.#store.previewGridResize(delta.deltaRows, delta.deltaColumns);
   }
 
-  // Commit a grid resize gesture by the track-count delta. Always clears the
-  // preview first; the store reads the current size as the base and clamps to
-  // content (shrink can't orphan widgets).
+  // Commit a grid resize gesture. The store clears the preview, no-ops on a
+  // zero delta, and otherwise commits the clamped relative resize.
   onGridResizeEnd(delta: GridResizeDelta): void {
-    this.#store.clearGridResizePreview();
-    if (delta.deltaColumns === 0 && delta.deltaRows === 0) return;
-
-    this.gridResized.emit(
-      this.#store.growGrid(delta.deltaRows, delta.deltaColumns)
+    const result = this.#store.endGridResize(
+      delta.deltaRows,
+      delta.deltaColumns
     );
+    if (result) this.gridResized.emit(result);
   }
 }

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -9,6 +9,7 @@ import {
   ElementRef,
   inject,
   input,
+  output,
   viewChild,
   viewChildren,
   afterNextRender,
@@ -18,7 +19,18 @@ import { CellContextMenuComponent } from '../cell/cell-context-menu.component';
 import { CellContextMenuService } from '../cell/cell-context-menu.service';
 import { DropZoneComponent } from '../drop-zone/drop-zone.component';
 import { EmptyCellContextMenuComponent } from '../drop-zone/empty-cell-context-menu.component';
-import { CellId, CellIdUtils, WidgetId, DragData, CellData } from '../models';
+import {
+  GridResizeHandleComponent,
+  GridResizeDelta,
+} from '../grid-resize-handle/grid-resize-handle.component';
+import {
+  CellId,
+  CellIdUtils,
+  WidgetId,
+  DragData,
+  CellData,
+  GridResizeResult,
+} from '../models';
 import { DashboardStore } from '../store/dashboard-store';
 
 @Component({
@@ -28,7 +40,8 @@ import { DashboardStore } from '../store/dashboard-store';
     CellComponent,
     DropZoneComponent,
     CellContextMenuComponent,
-    EmptyCellContextMenuComponent
+    EmptyCellContextMenuComponent,
+    GridResizeHandleComponent
 ],
   providers: [
     CellContextMenuService,
@@ -58,6 +71,9 @@ export class DashboardEditorComponent {
   gutterSize = input<string>('1em');
   gutters = computed(() => this.columns() + 1);
 
+  // Emitted when a grid resize handle commits a new size (after clamp-to-content).
+  gridResized = output<GridResizeResult>();
+
   // store signals
   cells = this.#store.cells;
   highlightedZones = this.#store.highlightedZones;
@@ -65,6 +81,11 @@ export class DashboardEditorComponent {
   invalidHighlightMap = this.#store.invalidHighlightMap;
   hoveredDropZone = this.#store.hoveredDropZone;
   resizePreviewMap = this.#store.resizePreviewMap;
+  cellDimensions = this.#store.gridCellDimensions;
+
+  // Hide grid resize handles while a widget drag is in progress to avoid
+  // conflicting gestures.
+  isDragActive = computed(() => !!this.#store.dragData());
 
   // Generate all possible cell positions for the grid
   dropzonePositions = computed(() => {
@@ -188,5 +209,17 @@ export class DashboardEditorComponent {
   onDragDrop(event: { data: DragData; target: { row: number; col: number } }) {
     this.#store.handleDrop(event.data, event.target);
     // Note: Store handles all validation and error handling internally
+  }
+
+  // Commit a grid resize gesture: add the track-count delta to the current
+  // dimensions. The store clamps to content (shrink can't orphan widgets).
+  onGridResizeEnd(delta: GridResizeDelta): void {
+    if (delta.deltaColumns === 0 && delta.deltaRows === 0) return;
+
+    const result = this.#store.setGridSize(
+      this.#store.rows() + delta.deltaRows,
+      this.#store.columns() + delta.deltaColumns
+    );
+    this.gridResized.emit(result);
   }
 }

--- a/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard-editor/dashboard-editor.component.ts
@@ -84,13 +84,12 @@ export class DashboardEditorComponent {
   cellDimensions = this.#store.gridCellDimensions;
   gridResizePreview = this.#store.gridResizePreview;
 
-  // Effective grid size = the live drag preview when one is active, otherwise
-  // the committed size. Drives the grid template, aspect-ratio and drop zones
-  // so the editor reflows under the handle without committing.
-  effectiveRows = computed(() => this.gridResizePreview()?.rows ?? this.rows());
-  effectiveColumns = computed(
-    () => this.gridResizePreview()?.columns ?? this.columns()
-  );
+  // Effective grid size (live preview when dragging, else committed) — shared
+  // from the store so the editor grid, the outer frame and the viewport
+  // letterboxing all reflow together. Drives the grid template, aspect-ratio
+  // and drop zones so the editor reflows under the handle without committing.
+  effectiveRows = this.#store.effectiveRows;
+  effectiveColumns = this.#store.effectiveColumns;
 
   // Hide grid resize handles while a widget drag is in progress to avoid
   // conflicting gestures.

--- a/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.html
+++ b/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.html
@@ -6,6 +6,7 @@
     [rows]="store.rows()"
     [columns]="store.columns()"
     [gutterSize]="store.gutterSize()"
+    (gridResized)="gridResized.emit($event)"
   ></ngx-dashboard-editor>
   } @else {
   <!-- Read-only viewer -->

--- a/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
@@ -27,6 +27,7 @@ import { EmptyCellContextMenuService } from '../services/empty-cell-context-menu
 import { ReservedSpace } from '../models/reserved-space';
 import {
   CellIdUtils,
+  GridResizeResult,
   GridSelection,
   SelectionFilterOptions,
   SelectionModifier,
@@ -71,6 +72,7 @@ export class DashboardComponent implements OnChanges {
 
   // Component outputs
   selectionComplete = output<GridSelection>();
+  gridResized = output<GridResizeResult>();
 
   // Store signals - shared by both child components
   cells = this.#store.cells;
@@ -201,6 +203,22 @@ export class DashboardComponent implements OnChanges {
 
   clearDashboard(): void {
     this.#store.clearDashboard();
+  }
+
+  /**
+   * Resize the dashboard grid to the given row/column counts.
+   *
+   * Uses a clamp-to-content policy: a size that would push an existing widget
+   * out of bounds is snapped up to the smallest size that still contains every
+   * widget, so shrinking never orphans a widget. The applied size (which may
+   * differ from the request when clamped) is returned and emitted via
+   * `gridResized`. Values below 1 are treated as 1; fractional values are
+   * floored.
+   */
+  setGridSize(rows: number, columns: number): GridResizeResult {
+    const result = this.#store.setGridSize(rows, columns);
+    this.gridResized.emit(result);
+    return result;
   }
 
   /**

--- a/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
@@ -42,10 +42,10 @@ import {
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',
   host: {
-    '[style.--rows]': 'store.rows()',
-    '[style.--columns]': 'store.columns()',
+    '[style.--rows]': 'store.effectiveRows()',
+    '[style.--columns]': 'store.effectiveColumns()',
     '[style.--gutter-size]': 'store.gutterSize()',
-    '[style.--gutters]': 'store.columns() + 1',
+    '[style.--gutters]': 'store.effectiveColumns() + 1',
     '[class.is-edit-mode]': 'editMode()',
     '[style.max-width.px]': 'viewport.constraints().maxWidth',
     '[style.max-height.px]': 'viewport.constraints().maxHeight',

--- a/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
+++ b/projects/ngx-dashboard/src/lib/dashboard/dashboard.component.ts
@@ -216,8 +216,14 @@ export class DashboardComponent implements OnChanges {
    * floored.
    */
   setGridSize(rows: number, columns: number): GridResizeResult {
+    const beforeRows = this.#store.rows();
+    const beforeColumns = this.#store.columns();
     const result = this.#store.setGridSize(rows, columns);
-    this.gridResized.emit(result);
+    // Only signal a resize when the committed size actually changed, matching
+    // the handle-drag path (store.endGridResize).
+    if (result.rows !== beforeRows || result.columns !== beforeColumns) {
+      this.gridResized.emit(result);
+    }
     return result;
   }
 

--- a/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.html
+++ b/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.html
@@ -4,6 +4,7 @@
   [class.drop-zone--highlight]="highlight() && !highlightInvalid()"
   [class.drop-zone--invalid]="highlightInvalid()"
   [class.drop-zone--resize]="highlightResize()"
+  [class.drop-zone--preview]="highlightPreview()"
   [style.grid-row]="row()"
   [style.grid-column]="col()"
   (dragenter)="onDragEnter($event)"

--- a/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.scss
+++ b/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.scss
@@ -40,6 +40,13 @@
   outline: 1px solid rgba(33, 150, 243, 0.6);
 }
 
+// Tracks being added by an in-progress grid resize preview
+.drop-zone--preview {
+  background-color: color-mix(in srgb, var(--mat-sys-primary) 18%, transparent);
+  outline: 1px dashed
+    color-mix(in srgb, var(--mat-sys-primary) 50%, transparent);
+}
+
 // Edit mode cell numbers - centered in cell
 .edit-mode-cell-number {
   // Text styling

--- a/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.ts
+++ b/projects/ngx-dashboard/src/lib/drop-zone/drop-zone.component.ts
@@ -32,6 +32,7 @@ export class DropZoneComponent {
   highlight = input(false);
   highlightInvalid = input(false);
   highlightResize = input(false);
+  highlightPreview = input(false);
   editMode = input(false);
 
   // Outputs

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
@@ -10,7 +10,6 @@ describe('GridResizeHandleComponent', () => {
   let host: HTMLElement;
   let lastDelta: GridResizeDelta | undefined;
   let moveDeltas: GridResizeDelta[];
-  let startCount: number;
   let endCount: number;
 
   function setup(axis: GridResizeAxis, cellWidth = 50, cellHeight = 40): void {
@@ -21,9 +20,7 @@ describe('GridResizeHandleComponent', () => {
 
     lastDelta = undefined;
     moveDeltas = [];
-    startCount = 0;
     endCount = 0;
-    fixture.componentInstance.resizeStart.subscribe(() => startCount++);
     fixture.componentInstance.resizeMove.subscribe((d) => moveDeltas.push(d));
     fixture.componentInstance.resizeEnd.subscribe((d) => {
       lastDelta = d;
@@ -58,13 +55,6 @@ describe('GridResizeHandleComponent', () => {
   });
 
   afterEach(() => fixture?.destroy());
-
-  it('emits resizeStart on mousedown', () => {
-    setup('both');
-    pointerDown(100, 100);
-    expect(startCount).toBe(1);
-    pointerUp();
-  });
 
   it('horizontal handle reports a column delta and zero rows', () => {
     setup('horizontal', 50, 40);

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
@@ -1,0 +1,120 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  GridResizeAxis,
+  GridResizeDelta,
+  GridResizeHandleComponent,
+} from '../grid-resize-handle.component';
+
+describe('GridResizeHandleComponent', () => {
+  let fixture: ComponentFixture<GridResizeHandleComponent>;
+  let host: HTMLElement;
+  let lastDelta: GridResizeDelta | undefined;
+  let startCount: number;
+  let endCount: number;
+
+  function setup(axis: GridResizeAxis, cellWidth = 50, cellHeight = 40): void {
+    fixture = TestBed.createComponent(GridResizeHandleComponent);
+    fixture.componentRef.setInput('axis', axis);
+    fixture.componentRef.setInput('cellWidth', cellWidth);
+    fixture.componentRef.setInput('cellHeight', cellHeight);
+
+    lastDelta = undefined;
+    startCount = 0;
+    endCount = 0;
+    fixture.componentInstance.resizeStart.subscribe(() => startCount++);
+    fixture.componentInstance.resizeEnd.subscribe((d) => {
+      lastDelta = d;
+      endCount++;
+    });
+
+    fixture.detectChanges();
+    host = fixture.nativeElement as HTMLElement;
+  }
+
+  function pointerDown(x: number, y: number): void {
+    host.dispatchEvent(
+      new MouseEvent('mousedown', { clientX: x, clientY: y, bubbles: true })
+    );
+  }
+  function pointerMove(x: number, y: number): void {
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y }));
+  }
+  function pointerUp(): void {
+    document.dispatchEvent(new MouseEvent('mouseup'));
+  }
+  function drag(fromX: number, fromY: number, toX: number, toY: number): void {
+    pointerDown(fromX, fromY);
+    pointerMove(toX, toY);
+    pointerUp();
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GridResizeHandleComponent],
+    });
+  });
+
+  afterEach(() => fixture?.destroy());
+
+  it('emits resizeStart on mousedown', () => {
+    setup('both');
+    pointerDown(100, 100);
+    expect(startCount).toBe(1);
+    pointerUp();
+  });
+
+  it('horizontal handle reports a column delta and zero rows', () => {
+    setup('horizontal', 50, 40);
+    // +120px x => round(120/50)=2 columns; vertical movement ignored.
+    drag(100, 100, 220, 300);
+    expect(lastDelta).toEqual({ deltaColumns: 2, deltaRows: 0 });
+  });
+
+  it('vertical handle reports a row delta and zero columns', () => {
+    setup('vertical', 50, 40);
+    // +120px y => round(120/40)=3 rows; horizontal movement ignored.
+    drag(100, 100, 400, 220);
+    expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 3 });
+  });
+
+  it('corner handle reports both axes, including negative (shrink) deltas', () => {
+    setup('both', 50, 40);
+    // dx=+160 => round(3.2)=3 cols; dy=-80 => round(-2)= -2 rows.
+    drag(200, 200, 360, 120);
+    expect(lastDelta).toEqual({ deltaColumns: 3, deltaRows: -2 });
+  });
+
+  it('emits a zero delta when the pointer does not move (no-op click)', () => {
+    setup('both', 50, 40);
+    drag(100, 100, 100, 100);
+    expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 0 });
+  });
+
+  it('reports zero when the cell footprint is unknown (0px)', () => {
+    setup('horizontal', 0, 0);
+    drag(100, 100, 400, 400);
+    expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 0 });
+  });
+
+  it('removes document listeners after the gesture ends', () => {
+    setup('horizontal', 50, 40);
+    drag(100, 100, 200, 100);
+    expect(endCount).toBe(1);
+
+    // A stray move/up after release must not produce another commit.
+    pointerMove(999, 999);
+    pointerUp();
+    expect(endCount).toBe(1);
+  });
+
+  it('toggles the is-active host class for the duration of the drag', () => {
+    setup('vertical', 50, 40);
+    pointerDown(100, 100);
+    fixture.detectChanges();
+    expect(host.classList).toContain('is-active');
+
+    pointerUp();
+    fixture.detectChanges();
+    expect(host.classList).not.toContain('is-active');
+  });
+});

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
@@ -33,14 +33,21 @@ describe('GridResizeHandleComponent', () => {
 
   function pointerDown(x: number, y: number): void {
     host.dispatchEvent(
-      new MouseEvent('mousedown', { clientX: x, clientY: y, bubbles: true })
+      new PointerEvent('pointerdown', {
+        clientX: x,
+        clientY: y,
+        pointerId: 1,
+        bubbles: true,
+      })
     );
   }
   function pointerMove(x: number, y: number): void {
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y }));
+    document.dispatchEvent(
+      new PointerEvent('pointermove', { clientX: x, clientY: y, pointerId: 1 })
+    );
   }
   function pointerUp(): void {
-    document.dispatchEvent(new MouseEvent('mouseup'));
+    document.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1 }));
   }
   function drag(fromX: number, fromY: number, toX: number, toY: number): void {
     pointerDown(fromX, fromY);
@@ -77,6 +84,33 @@ describe('GridResizeHandleComponent', () => {
     expect(lastDelta).toEqual({ deltaColumns: 3, deltaRows: -2 });
   });
 
+  it('rounds half-cell drags symmetrically inward and outward', () => {
+    // Outward half-cell => +1.
+    setup('horizontal', 50, 40);
+    drag(100, 100, 125, 100);
+    expect(lastDelta).toEqual({ deltaColumns: 1, deltaRows: 0 });
+
+    // Inward half-cell => -1 (plain Math.round(-0.5) would give 0).
+    setup('horizontal', 50, 40);
+    drag(100, 100, 75, 100);
+    expect(lastDelta).toEqual({ deltaColumns: -1, deltaRows: 0 });
+  });
+
+  it('uses the cell size captured at gesture start, not the live (shrinking) size', () => {
+    setup('horizontal', 50, 40);
+    pointerDown(100, 100);
+
+    // The editor's live reflow shrinks the cell size mid-drag...
+    fixture.componentRef.setInput('cellWidth', 25);
+    fixture.detectChanges();
+
+    // ...but the divisor stays the 50px snapshot => 100/50 = 2, not 100/25 = 4.
+    pointerMove(200, 100);
+    expect(moveDeltas.at(-1)).toEqual({ deltaColumns: 2, deltaRows: 0 });
+
+    pointerUp();
+  });
+
   it('emits resizeMove only when the rounded track delta changes', () => {
     setup('horizontal', 50, 40);
     pointerDown(100, 100);
@@ -107,6 +141,29 @@ describe('GridResizeHandleComponent', () => {
     setup('horizontal', 0, 0);
     drag(100, 100, 400, 400);
     expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 0 });
+  });
+
+  it('aborts with a zero delta (no commit) on pointercancel', () => {
+    setup('both', 50, 40);
+    pointerDown(200, 200);
+    pointerMove(360, 120); // would commit {3, -2} on a normal release
+    expect(moveDeltas.length).toBeGreaterThan(0);
+
+    document.dispatchEvent(new PointerEvent('pointercancel', { pointerId: 1 }));
+
+    expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 0 });
+    expect(endCount).toBe(1);
+  });
+
+  it('aborts with a zero delta on window blur (pointer up lost outside window)', () => {
+    setup('both', 50, 40);
+    pointerDown(200, 200);
+    pointerMove(360, 120);
+
+    window.dispatchEvent(new Event('blur'));
+
+    expect(lastDelta).toEqual({ deltaColumns: 0, deltaRows: 0 });
+    expect(endCount).toBe(1);
   });
 
   it('removes document listeners after the gesture ends', () => {

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/__tests__/grid-resize-handle.component.spec.ts
@@ -9,6 +9,7 @@ describe('GridResizeHandleComponent', () => {
   let fixture: ComponentFixture<GridResizeHandleComponent>;
   let host: HTMLElement;
   let lastDelta: GridResizeDelta | undefined;
+  let moveDeltas: GridResizeDelta[];
   let startCount: number;
   let endCount: number;
 
@@ -19,9 +20,11 @@ describe('GridResizeHandleComponent', () => {
     fixture.componentRef.setInput('cellHeight', cellHeight);
 
     lastDelta = undefined;
+    moveDeltas = [];
     startCount = 0;
     endCount = 0;
     fixture.componentInstance.resizeStart.subscribe(() => startCount++);
+    fixture.componentInstance.resizeMove.subscribe((d) => moveDeltas.push(d));
     fixture.componentInstance.resizeEnd.subscribe((d) => {
       lastDelta = d;
       endCount++;
@@ -82,6 +85,26 @@ describe('GridResizeHandleComponent', () => {
     // dx=+160 => round(3.2)=3 cols; dy=-80 => round(-2)= -2 rows.
     drag(200, 200, 360, 120);
     expect(lastDelta).toEqual({ deltaColumns: 3, deltaRows: -2 });
+  });
+
+  it('emits resizeMove only when the rounded track delta changes', () => {
+    setup('horizontal', 50, 40);
+    pointerDown(100, 100);
+
+    pointerMove(120, 100); // +20px => round(0.4)=0, no change from start
+    expect(moveDeltas.length).toBe(0);
+
+    pointerMove(180, 100); // +80px => round(1.6)=2 columns
+    pointerMove(185, 100); // +85px => round(1.7)=2 columns, unchanged
+    expect(moveDeltas).toEqual([{ deltaColumns: 2, deltaRows: 0 }]);
+
+    pointerMove(230, 100); // +130px => round(2.6)=3 columns
+    expect(moveDeltas).toEqual([
+      { deltaColumns: 2, deltaRows: 0 },
+      { deltaColumns: 3, deltaRows: 0 },
+    ]);
+
+    pointerUp();
   });
 
   it('emits a zero delta when the pointer does not move (no-op click)', () => {

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.html
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.html
@@ -1,0 +1,2 @@
+<!-- grid-resize-handle.component.html -->
+<div class="grip-line"></div>

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
@@ -1,0 +1,82 @@
+/* grid-resize-handle.component.scss */
+
+/*
+ * The handle lives in the grid's outer gutter (the grid already pads its
+ * content by `--gutter-size`, so the outermost cells are inset). Sitting in
+ * that gutter keeps the handle off widget content without reserving a fixed
+ * band that would break the square-cell aspect math.
+ */
+:host {
+  position: absolute;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.3;
+  transition: opacity 0.15s ease;
+  touch-action: none;
+}
+
+:host(.axis-horizontal) {
+  cursor: col-resize;
+  top: 0;
+  right: 0;
+  width: 14px;
+  height: 100%;
+}
+
+:host(.axis-vertical) {
+  cursor: row-resize;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 14px;
+}
+
+:host(.axis-both) {
+  cursor: nwse-resize;
+  right: 0;
+  bottom: 0;
+  width: 18px;
+  height: 18px;
+  z-index: 26; /* corner sits above the edge strips where they overlap */
+}
+
+:host(:hover),
+:host(.is-active) {
+  opacity: 1;
+}
+
+.grip-line {
+  background-color: var(--mat-sys-outline-variant);
+  border-radius: 2px;
+}
+
+:host(.axis-horizontal) .grip-line {
+  width: 4px;
+  height: 48px;
+  max-height: 60%;
+}
+
+:host(.axis-vertical) .grip-line {
+  width: 48px;
+  max-width: 60%;
+  height: 4px;
+}
+
+:host(.axis-both) .grip-line {
+  width: 10px;
+  height: 10px;
+  border-bottom-right-radius: 4px;
+}
+
+:host(:hover) .grip-line,
+:host(.is-active) .grip-line {
+  background-color: var(--mat-sys-primary);
+}
+
+/* Global cursor while dragging the corner handle (col/row variants are
+   already defined by the cell resize handle). Applied to document.body. */
+:root .cursor-nwse-resize {
+  cursor: nwse-resize !important;
+}

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
@@ -17,11 +17,17 @@
   touch-action: none;
 }
 
+/*
+ * Width/height track the gutter so the handle sits in the grid's outer gutter
+ * rather than overlapping the rightmost/bottommost widget cells. A small floor
+ * keeps a grabbable target when the gutter is tiny (worst case a few px of
+ * overlap, vs. a fixed strip always overlapping at the default gutter).
+ */
 :host(.axis-horizontal) {
   cursor: col-resize;
   top: 0;
   right: 0;
-  width: 14px;
+  width: max(var(--gutter-size, 8px), 6px);
   height: 100%;
 }
 
@@ -30,15 +36,15 @@
   left: 0;
   bottom: 0;
   width: 100%;
-  height: 14px;
+  height: max(var(--gutter-size, 8px), 6px);
 }
 
 :host(.axis-both) {
   cursor: nwse-resize;
   right: 0;
   bottom: 0;
-  width: 18px;
-  height: 18px;
+  width: max(var(--gutter-size, 8px), 8px);
+  height: max(var(--gutter-size, 8px), 8px);
   z-index: 26; /* corner sits above the edge strips where they overlap */
 }
 
@@ -65,9 +71,9 @@
 }
 
 :host(.axis-both) .grip-line {
-  width: 10px;
-  height: 10px;
-  border-bottom-right-radius: 4px;
+  width: 6px;
+  height: 6px;
+  border-bottom-right-radius: 3px;
 }
 
 :host(:hover) .grip-line,

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
@@ -1,4 +1,5 @@
 /* grid-resize-handle.component.scss */
+@use "../styles/resize-cursors";
 
 /*
  * The handle lives in the grid's outer gutter (the grid already pads its
@@ -79,17 +80,4 @@
 :host(:hover) .grip-line,
 :host(.is-active) .grip-line {
   background-color: var(--mat-sys-primary);
-}
-
-/* Global body cursors applied (via Renderer2) for the duration of a handle
-   drag. Defined here so the handle is self-contained and does not depend on
-   another component's stylesheet for the classes it sets on document.body. */
-:root .cursor-col-resize {
-  cursor: col-resize !important;
-}
-:root .cursor-row-resize {
-  cursor: row-resize !important;
-}
-:root .cursor-nwse-resize {
-  cursor: nwse-resize !important;
 }

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.scss
@@ -75,8 +75,15 @@
   background-color: var(--mat-sys-primary);
 }
 
-/* Global cursor while dragging the corner handle (col/row variants are
-   already defined by the cell resize handle). Applied to document.body. */
+/* Global body cursors applied (via Renderer2) for the duration of a handle
+   drag. Defined here so the handle is self-contained and does not depend on
+   another component's stylesheet for the classes it sets on document.body. */
+:root .cursor-col-resize {
+  cursor: col-resize !important;
+}
+:root .cursor-row-resize {
+  cursor: row-resize !important;
+}
 :root .cursor-nwse-resize {
   cursor: nwse-resize !important;
 }

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -50,6 +50,7 @@ export class GridResizeHandleComponent {
   cellHeight = input.required<number>();
 
   resizeStart = output<void>();
+  resizeMove = output<GridResizeDelta>();
   resizeEnd = output<GridResizeDelta>();
 
   readonly #renderer = inject(Renderer2);
@@ -98,7 +99,7 @@ export class GridResizeHandleComponent {
     const width = this.cellWidth();
     const height = this.cellHeight();
 
-    this.#delta = {
+    const next: GridResizeDelta = {
       deltaColumns:
         axis !== 'vertical' && width > 0
           ? Math.round((event.clientX - this.#startX) / width)
@@ -108,6 +109,18 @@ export class GridResizeHandleComponent {
           ? Math.round((event.clientY - this.#startY) / height)
           : 0,
     };
+
+    // Only emit when the rounded track delta actually changes, so sub-cell
+    // pointer movement doesn't spam the live preview.
+    if (
+      next.deltaColumns === this.#delta.deltaColumns &&
+      next.deltaRows === this.#delta.deltaRows
+    ) {
+      return;
+    }
+
+    this.#delta = next;
+    this.resizeMove.emit(next);
   };
 
   readonly #onUp = (): void => {

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -37,9 +37,7 @@ export interface GridResizeDelta {
   templateUrl: './grid-resize-handle.component.html',
   styleUrl: './grid-resize-handle.component.scss',
   host: {
-    '[class.axis-horizontal]': "axis() === 'horizontal'",
-    '[class.axis-vertical]': "axis() === 'vertical'",
-    '[class.axis-both]': "axis() === 'both'",
+    '[class]': "'axis-' + axis()",
     '[class.is-active]': 'isActive()',
     '(mousedown)': 'onResizeStart($event)',
   },

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -1,9 +1,9 @@
 // grid-resize-handle.component.ts
 //
 // A small, self-contained drag handle for resizing the dashboard grid's
-// row/column counts from the editor. It mirrors the cell resize gesture
-// (mousedown -> document listeners via Renderer2 -> delta in track counts)
-// but reports a whole-grid delta rather than a per-widget span change.
+// row/column counts from the editor. Uses PointerEvents (with pointer capture)
+// so mouse, touch and pen all work uniformly, and reports a whole-grid delta
+// in track counts rather than a per-widget span change.
 //
 // The handle is intentionally store-agnostic: it converts pointer movement
 // into track-count deltas using the cell footprint passed in, and emits them.
@@ -13,6 +13,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   inject,
   input,
   output,
@@ -29,6 +30,15 @@ export interface GridResizeDelta {
   deltaRows: number;
 }
 
+/**
+ * Round half away from zero so inward and outward half-cell drags behave
+ * symmetrically. `Math.round` rounds 0.5 to 1 but -0.5 to 0, which makes a
+ * half-cell shrink "stick" while a half-cell grow responds.
+ */
+function symmetricRound(value: number): number {
+  return Math.sign(value) * Math.round(Math.abs(value));
+}
+
 @Component({
   selector: 'lib-grid-resize-handle',
   standalone: true,
@@ -39,7 +49,7 @@ export interface GridResizeDelta {
   host: {
     '[class]': "'axis-' + axis()",
     '[class.is-active]': 'isActive()',
-    '(mousedown)': 'onResizeStart($event)',
+    '(pointerdown)': 'onResizeStart($event)',
   },
 })
 export class GridResizeHandleComponent {
@@ -52,6 +62,7 @@ export class GridResizeHandleComponent {
   resizeMove = output<GridResizeDelta>();
   resizeEnd = output<GridResizeDelta>();
 
+  readonly #host = inject<ElementRef<HTMLElement>>(ElementRef);
   readonly #renderer = inject(Renderer2);
   readonly #destroyRef = inject(DestroyRef);
 
@@ -59,52 +70,85 @@ export class GridResizeHandleComponent {
 
   #startX = 0;
   #startY = 0;
+  // Cell footprint snapshot taken at gesture start. Reading the live signal
+  // would feed back on itself: the editor's live preview shrinks cells as
+  // columns are added, which would shrink this px->track divisor mid-drag and
+  // make the grid overshoot.
+  #cellWidth = 0;
+  #cellHeight = 0;
+  #pointerId: number | null = null;
   #delta: GridResizeDelta = { deltaColumns: 0, deltaRows: 0 };
   #cleanup?: () => void;
 
   constructor() {
-    // Defensive: drop document listeners if the handle is torn down mid-drag.
+    // Defensive: drop listeners / capture if the handle is torn down mid-drag.
     this.#destroyRef.onDestroy(() => this.#stop());
   }
 
-  onResizeStart(event: MouseEvent): void {
+  onResizeStart(event: PointerEvent): void {
     event.preventDefault();
     event.stopPropagation();
 
     this.#startX = event.clientX;
     this.#startY = event.clientY;
+    this.#cellWidth = this.cellWidth();
+    this.#cellHeight = this.cellHeight();
     this.#delta = { deltaColumns: 0, deltaRows: 0 };
     this.isActive.set(true);
 
-    // Document-level listeners only exist while actively dragging this handle.
+    // Capture so the gesture keeps receiving events even if the pointer leaves
+    // the thin handle strip; tolerate environments without capture support.
+    const host = this.#host.nativeElement;
+    if (host.setPointerCapture) {
+      try {
+        host.setPointerCapture(event.pointerId);
+        this.#pointerId = event.pointerId;
+      } catch {
+        this.#pointerId = null;
+      }
+    }
+
+    // Document/window listeners only exist while actively dragging this handle.
     const unlistenMove = this.#renderer.listen(
       'document',
-      'mousemove',
+      'pointermove',
       this.#onMove
     );
-    const unlistenUp = this.#renderer.listen('document', 'mouseup', this.#onUp);
+    const unlistenUp = this.#renderer.listen(
+      'document',
+      'pointerup',
+      this.#onUp
+    );
+    const unlistenCancel = this.#renderer.listen(
+      'document',
+      'pointercancel',
+      this.#onAbort
+    );
+    // A pointerup that lands outside the window never fires; window blur is the
+    // backstop that aborts a gesture the browser has otherwise abandoned.
+    const unlistenBlur = this.#renderer.listen('window', 'blur', this.#onAbort);
     this.#cleanup = () => {
       unlistenMove();
       unlistenUp();
+      unlistenCancel();
+      unlistenBlur();
     };
 
     this.#renderer.addClass(document.body, this.#cursorClass());
   }
 
   // Arrow fields keep `this` bound when used as Renderer2 listener callbacks.
-  readonly #onMove = (event: MouseEvent): void => {
+  readonly #onMove = (event: PointerEvent): void => {
     const axis = this.axis();
-    const width = this.cellWidth();
-    const height = this.cellHeight();
 
     const next: GridResizeDelta = {
       deltaColumns:
-        axis !== 'vertical' && width > 0
-          ? Math.round((event.clientX - this.#startX) / width)
+        axis !== 'vertical' && this.#cellWidth > 0
+          ? symmetricRound((event.clientX - this.#startX) / this.#cellWidth)
           : 0,
       deltaRows:
-        axis !== 'horizontal' && height > 0
-          ? Math.round((event.clientY - this.#startY) / height)
+        axis !== 'horizontal' && this.#cellHeight > 0
+          ? symmetricRound((event.clientY - this.#startY) / this.#cellHeight)
           : 0,
     };
 
@@ -121,15 +165,33 @@ export class GridResizeHandleComponent {
     this.resizeMove.emit(next);
   };
 
-  readonly #onUp = (): void => {
-    const delta = this.#delta;
+  readonly #onUp = (): void => this.#finish(this.#delta);
+
+  // Abort (pointercancel / window blur): discard the in-progress delta so the
+  // editor clears the preview without committing a half-finished gesture.
+  readonly #onAbort = (): void =>
+    this.#finish({ deltaColumns: 0, deltaRows: 0 });
+
+  #finish(delta: GridResizeDelta): void {
+    if (!this.isActive()) return;
     this.#stop();
     this.resizeEnd.emit(delta);
-  };
+  }
 
   #stop(): void {
     this.isActive.set(false);
     this.#renderer.removeClass(document.body, this.#cursorClass());
+
+    const host = this.#host.nativeElement;
+    if (this.#pointerId !== null && host.releasePointerCapture) {
+      try {
+        host.releasePointerCapture(this.#pointerId);
+      } catch {
+        // Capture may already be gone (e.g. pointercancel released it).
+      }
+    }
+    this.#pointerId = null;
+
     this.#cleanup?.();
     this.#cleanup = undefined;
   }

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -49,7 +49,6 @@ export class GridResizeHandleComponent {
   cellWidth = input.required<number>();
   cellHeight = input.required<number>();
 
-  resizeStart = output<void>();
   resizeMove = output<GridResizeDelta>();
   resizeEnd = output<GridResizeDelta>();
 
@@ -76,7 +75,6 @@ export class GridResizeHandleComponent {
     this.#startY = event.clientY;
     this.#delta = { deltaColumns: 0, deltaRows: 0 };
     this.isActive.set(true);
-    this.resizeStart.emit();
 
     // Document-level listeners only exist while actively dragging this handle.
     const unlistenMove = this.#renderer.listen(

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -1,0 +1,138 @@
+// grid-resize-handle.component.ts
+//
+// A small, self-contained drag handle for resizing the dashboard grid's
+// row/column counts from the editor. It mirrors the cell resize gesture
+// (mousedown -> document listeners via Renderer2 -> delta in track counts)
+// but reports a whole-grid delta rather than a per-widget span change.
+//
+// The handle is intentionally store-agnostic: it converts pointer movement
+// into track-count deltas using the cell footprint passed in, and emits them.
+// The editor owns the actual grid mutation (clamp-to-content lives there).
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  input,
+  output,
+  Renderer2,
+  signal,
+} from '@angular/core';
+
+/** Which axis (or both, for the corner handle) the handle resizes. */
+export type GridResizeAxis = 'horizontal' | 'vertical' | 'both';
+
+/** Track-count delta produced by a handle drag. Zero on the inactive axis. */
+export interface GridResizeDelta {
+  deltaColumns: number;
+  deltaRows: number;
+}
+
+@Component({
+  selector: 'lib-grid-resize-handle',
+  standalone: true,
+  imports: [],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './grid-resize-handle.component.html',
+  styleUrl: './grid-resize-handle.component.scss',
+  host: {
+    '[class.axis-horizontal]': "axis() === 'horizontal'",
+    '[class.axis-vertical]': "axis() === 'vertical'",
+    '[class.axis-both]': "axis() === 'both'",
+    '[class.is-active]': 'isActive()',
+    '(mousedown)': 'onResizeStart($event)',
+  },
+})
+export class GridResizeHandleComponent {
+  axis = input.required<GridResizeAxis>();
+
+  /** Current grid cell footprint in px; converts pointer delta to track counts. */
+  cellWidth = input.required<number>();
+  cellHeight = input.required<number>();
+
+  resizeStart = output<void>();
+  resizeEnd = output<GridResizeDelta>();
+
+  readonly #renderer = inject(Renderer2);
+  readonly #destroyRef = inject(DestroyRef);
+
+  protected readonly isActive = signal(false);
+
+  #startX = 0;
+  #startY = 0;
+  #delta: GridResizeDelta = { deltaColumns: 0, deltaRows: 0 };
+  #cleanup?: () => void;
+
+  constructor() {
+    // Defensive: drop document listeners if the handle is torn down mid-drag.
+    this.#destroyRef.onDestroy(() => this.#stop());
+  }
+
+  onResizeStart(event: MouseEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.#startX = event.clientX;
+    this.#startY = event.clientY;
+    this.#delta = { deltaColumns: 0, deltaRows: 0 };
+    this.isActive.set(true);
+    this.resizeStart.emit();
+
+    // Document-level listeners only exist while actively dragging this handle.
+    const unlistenMove = this.#renderer.listen(
+      'document',
+      'mousemove',
+      this.#onMove
+    );
+    const unlistenUp = this.#renderer.listen('document', 'mouseup', this.#onUp);
+    this.#cleanup = () => {
+      unlistenMove();
+      unlistenUp();
+    };
+
+    this.#renderer.addClass(document.body, this.#cursorClass());
+  }
+
+  // Arrow fields keep `this` bound when used as Renderer2 listener callbacks.
+  readonly #onMove = (event: MouseEvent): void => {
+    const axis = this.axis();
+    const width = this.cellWidth();
+    const height = this.cellHeight();
+
+    this.#delta = {
+      deltaColumns:
+        axis !== 'vertical' && width > 0
+          ? Math.round((event.clientX - this.#startX) / width)
+          : 0,
+      deltaRows:
+        axis !== 'horizontal' && height > 0
+          ? Math.round((event.clientY - this.#startY) / height)
+          : 0,
+    };
+  };
+
+  readonly #onUp = (): void => {
+    const delta = this.#delta;
+    this.#stop();
+    this.resizeEnd.emit(delta);
+  };
+
+  #stop(): void {
+    this.isActive.set(false);
+    this.#renderer.removeClass(document.body, this.#cursorClass());
+    this.#cleanup?.();
+    this.#cleanup = undefined;
+  }
+
+  #cursorClass(): string {
+    switch (this.axis()) {
+      case 'horizontal':
+        return 'cursor-col-resize';
+      case 'vertical':
+        return 'cursor-row-resize';
+      default:
+        return 'cursor-nwse-resize';
+    }
+  }
+}

--- a/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
+++ b/projects/ngx-dashboard/src/lib/grid-resize-handle/grid-resize-handle.component.ts
@@ -97,15 +97,13 @@ export class GridResizeHandleComponent {
     this.isActive.set(true);
 
     // Capture so the gesture keeps receiving events even if the pointer leaves
-    // the thin handle strip; tolerate environments without capture support.
-    const host = this.#host.nativeElement;
-    if (host.setPointerCapture) {
-      try {
-        host.setPointerCapture(event.pointerId);
-        this.#pointerId = event.pointerId;
-      } catch {
-        this.#pointerId = null;
-      }
+    // the thin handle strip. try/catch tolerates environments without capture
+    // support (TypeError) and synthetic test events with no active pointer.
+    try {
+      this.#host.nativeElement.setPointerCapture(event.pointerId);
+      this.#pointerId = event.pointerId;
+    } catch {
+      // No capture; the document listeners still drive the gesture.
     }
 
     // Document/window listeners only exist while actively dragging this handle.
@@ -182,10 +180,9 @@ export class GridResizeHandleComponent {
     this.isActive.set(false);
     this.#renderer.removeClass(document.body, this.#cursorClass());
 
-    const host = this.#host.nativeElement;
-    if (this.#pointerId !== null && host.releasePointerCapture) {
+    if (this.#pointerId !== null) {
       try {
-        host.releasePointerCapture(this.#pointerId);
+        this.#host.nativeElement.releasePointerCapture(this.#pointerId);
       } catch {
         // Capture may already be gone (e.g. pointercancel released it).
       }

--- a/projects/ngx-dashboard/src/lib/models/grid-resize-result.ts
+++ b/projects/ngx-dashboard/src/lib/models/grid-resize-result.ts
@@ -1,0 +1,17 @@
+/**
+ * Outcome of a grid resize request (e.g. `DashboardComponent.setGridSize()`
+ * or an editor drag-handle commit).
+ *
+ * The dashboard uses a clamp-to-content policy: a requested size that would
+ * push an existing widget outside the grid is snapped up to the smallest size
+ * that still contains every widget's full footprint. The fields below report
+ * the size that was actually applied, not the size that was requested.
+ */
+export interface GridResizeResult {
+  /** Rows actually applied after clamp-to-content. */
+  rows: number;
+  /** Columns actually applied after clamp-to-content. */
+  columns: number;
+  /** True when the requested size was clamped up to keep widgets in bounds. */
+  clamped: boolean;
+}

--- a/projects/ngx-dashboard/src/lib/models/index.ts
+++ b/projects/ngx-dashboard/src/lib/models/index.ts
@@ -7,6 +7,7 @@ export * from './dashboard-data.dto';
 export * from './dashboard-data.utils';
 export * from './drag-data';
 export * from './grid-selection';
+export * from './grid-resize-result';
 export * from './reserved-space';
 export * from './selection-filter-options';
 export * from './selection-modifier';

--- a/projects/ngx-dashboard/src/lib/services/dashboard-viewport.service.ts
+++ b/projects/ngx-dashboard/src/lib/services/dashboard-viewport.service.ts
@@ -102,10 +102,11 @@ export class DashboardViewportService {
    */
   readonly constraints = computed((): DashboardConstraints => {
     const availableSize = this.availableSpace();
-    
-    // Get grid configuration from our component's store
-    const rows = this.store.rows();
-    const columns = this.store.columns();
+
+    // Use the effective (preview-aware) size so the letterboxed frame reflows
+    // to fit during a grid-resize drag instead of overflowing/scrolling.
+    const rows = this.store.effectiveRows();
+    const columns = this.store.effectiveColumns();
     
     if (rows === 0 || columns === 0) {
       return {

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -143,6 +143,36 @@ describe('DashboardStore - Grid Configuration', () => {
     });
   });
 
+  describe('growGrid', () => {
+    it('should apply a positive delta relative to the current size', () => {
+      // Starts at 8 x 16.
+      const result = store.growGrid(2, -3);
+
+      expect(store.rows()).toBe(10);
+      expect(store.columns()).toBe(13);
+      expect(result).toEqual({ rows: 10, columns: 13, clamped: false });
+    });
+
+    it('should clamp a shrinking delta to the content floor', () => {
+      placeWidget(6, 10); // furthest widget origin
+
+      // Shrink request lands below the occupied extent on both axes.
+      const result = store.growGrid(-5, -8);
+
+      expect(store.rows()).toBe(6);
+      expect(store.columns()).toBe(10);
+      expect(result.clamped).toBe(true);
+    });
+
+    it('should be a no-op for a zero delta', () => {
+      const result = store.growGrid(0, 0);
+
+      expect(store.rows()).toBe(8);
+      expect(store.columns()).toBe(16);
+      expect(result).toEqual({ rows: 8, columns: 16, clamped: false });
+    });
+  });
+
   describe('setGridCellDimensions', () => {
     it('should update grid cell dimensions', () => {
       store.setGridCellDimensions(100, 50);

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -141,35 +141,15 @@ describe('DashboardStore - Grid Configuration', () => {
       expect(store.columns()).toBe(5);
       expect(result).toEqual({ rows: 1, columns: 5, clamped: false });
     });
-  });
 
-  describe('growGrid', () => {
-    it('should apply a positive delta relative to the current size', () => {
-      // Starts at 8 x 16.
-      const result = store.growGrid(2, -3);
+    it('should sanitize non-finite requests instead of committing NaN', () => {
+      const result = store.setGridSize(NaN, Infinity);
 
-      expect(store.rows()).toBe(10);
-      expect(store.columns()).toBe(13);
-      expect(result).toEqual({ rows: 10, columns: 13, clamped: false });
-    });
-
-    it('should clamp a shrinking delta to the content floor', () => {
-      placeWidget(6, 10); // furthest widget origin
-
-      // Shrink request lands below the occupied extent on both axes.
-      const result = store.growGrid(-5, -8);
-
-      expect(store.rows()).toBe(6);
-      expect(store.columns()).toBe(10);
-      expect(result.clamped).toBe(true);
-    });
-
-    it('should be a no-op for a zero delta', () => {
-      const result = store.growGrid(0, 0);
-
-      expect(store.rows()).toBe(8);
-      expect(store.columns()).toBe(16);
-      expect(result).toEqual({ rows: 8, columns: 16, clamped: false });
+      // Non-finite -> 1, then clamped to content (empty dashboard floor = 1).
+      expect(store.rows()).toBe(1);
+      expect(store.columns()).toBe(1);
+      expect(Number.isFinite(result.rows)).toBe(true);
+      expect(Number.isFinite(result.columns)).toBe(true);
     });
   });
 
@@ -233,6 +213,27 @@ describe('DashboardStore - Grid Configuration', () => {
       expect(store.rows()).toBe(8);
       expect(store.columns()).toBe(16);
       expect(store.gridResizePreview()).toBeNull();
+    });
+
+    it('should return null when clamp-to-content leaves the size unchanged', () => {
+      placeWidget(8, 16); // pins the content floor at the current size
+
+      // Non-zero shrink delta, but it clamps straight back to 8 x 16.
+      const result = store.endGridResize(-2, -3);
+
+      expect(result).toBeNull();
+      expect(store.rows()).toBe(8);
+      expect(store.columns()).toBe(16);
+    });
+
+    it('should clamp a relative shrink to the content floor', () => {
+      placeWidget(6, 10);
+
+      const result = store.endGridResize(-5, -8);
+
+      expect(result).toEqual({ rows: 6, columns: 10, clamped: true });
+      expect(store.rows()).toBe(6);
+      expect(store.columns()).toBe(10);
     });
   });
 

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -1,22 +1,49 @@
 import { TestBed } from '@angular/core/testing';
 import { DashboardService } from '../../services/dashboard.service';
 import { DashboardStore } from '../dashboard-store';
+import { CellData, CellIdUtils, WidgetFactory, WidgetIdUtils } from '../../models';
 
 describe('DashboardStore - Grid Configuration', () => {
   let store: InstanceType<typeof DashboardStore>;
+  let mockWidgetFactory: WidgetFactory;
+
+  /** Helper: place a widget at (row,col) with the given span. */
+  function placeWidget(
+    row: number,
+    col: number,
+    rowSpan = 1,
+    colSpan = 1
+  ): void {
+    const cell: CellData = {
+      widgetId: WidgetIdUtils.generate(),
+      cellId: CellIdUtils.create(row, col),
+      row,
+      col,
+      rowSpan,
+      colSpan,
+      widgetFactory: mockWidgetFactory,
+      widgetState: {},
+    };
+    store.addWidget(cell);
+  }
 
   beforeEach(() => {
     const dashboardServiceSpy = jasmine.createSpyObj('DashboardService', ['getFactory', 'collectSharedStates', 'restoreSharedStates', 'widgetTypes']);
-    
+
     TestBed.configureTestingModule({
       providers: [
         DashboardStore,
         { provide: DashboardService, useValue: dashboardServiceSpy }
       ]
     });
-    
+
     store = TestBed.inject(DashboardStore);
     store.setGridConfig({ rows: 8, columns: 16 });
+
+    mockWidgetFactory = {
+      widgetTypeid: 'test-widget',
+      createComponent: jasmine.createSpy(),
+    } as unknown as WidgetFactory;
   });
 
   describe('setGridConfig', () => {
@@ -52,6 +79,67 @@ describe('DashboardStore - Grid Configuration', () => {
       expect(store.rows()).toBe(1);
       expect(store.columns()).toBe(1);
       expect(store.gutterSize()).toBe('0px');
+    });
+  });
+
+  describe('setGridSize', () => {
+    it('should grow rows and columns on an empty dashboard', () => {
+      const result = store.setGridSize(12, 24);
+
+      expect(store.rows()).toBe(12);
+      expect(store.columns()).toBe(24);
+      expect(result).toEqual({ rows: 12, columns: 24, clamped: false });
+    });
+
+    it('should shrink freely when no widget blocks the new bounds', () => {
+      placeWidget(2, 3); // occupies up to row 2, col 3
+
+      const result = store.setGridSize(4, 6);
+
+      expect(store.rows()).toBe(4);
+      expect(store.columns()).toBe(6);
+      expect(result.clamped).toBe(false);
+    });
+
+    it('should clamp shrink up to the occupied row/column extent', () => {
+      placeWidget(6, 10); // furthest widget origin
+
+      const result = store.setGridSize(2, 2);
+
+      expect(store.rows()).toBe(6);
+      expect(store.columns()).toBe(10);
+      expect(result).toEqual({ rows: 6, columns: 10, clamped: true });
+    });
+
+    it('should account for widget span when computing the content floor', () => {
+      // Origin at col 14 but spans 3 columns => needs at least 16 columns,
+      // origin at row 7 spanning 2 rows => needs at least 8 rows.
+      placeWidget(7, 14, 2, 3);
+
+      const result = store.setGridSize(4, 4);
+
+      expect(store.rows()).toBe(8);
+      expect(store.columns()).toBe(16);
+      expect(result.clamped).toBe(true);
+    });
+
+    it('should clamp only the constrained axis', () => {
+      placeWidget(6, 2); // tall content, narrow content
+
+      const result = store.setGridSize(3, 5);
+
+      // Rows clamped up to 6, columns honored at 5.
+      expect(store.rows()).toBe(6);
+      expect(store.columns()).toBe(5);
+      expect(result).toEqual({ rows: 6, columns: 5, clamped: true });
+    });
+
+    it('should floor fractional requests and never go below 1', () => {
+      const result = store.setGridSize(0, 5.9);
+
+      expect(store.rows()).toBe(1);
+      expect(store.columns()).toBe(5);
+      expect(result).toEqual({ rows: 1, columns: 5, clamped: false });
     });
   });
 

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -190,6 +190,19 @@ describe('DashboardStore - Grid Configuration', () => {
       store.clearGridResizePreview();
       expect(store.gridResizePreview()).toBeNull();
     });
+
+    it('should expose effective dimensions that follow the preview', () => {
+      expect(store.effectiveRows()).toBe(8);
+      expect(store.effectiveColumns()).toBe(16);
+
+      store.previewGridResize(2, 3);
+      expect(store.effectiveRows()).toBe(10);
+      expect(store.effectiveColumns()).toBe(19);
+
+      store.clearGridResizePreview();
+      expect(store.effectiveRows()).toBe(8);
+      expect(store.effectiveColumns()).toBe(16);
+    });
   });
 
   describe('endGridResize', () => {

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -173,6 +173,45 @@ describe('DashboardStore - Grid Configuration', () => {
     });
   });
 
+  describe('grid resize preview', () => {
+    it('should start with no preview', () => {
+      expect(store.gridResizePreview()).toBeNull();
+    });
+
+    it('should store a clamped preview without committing the size', () => {
+      store.previewGridResize(3, 4);
+
+      // Preview reflects the would-be size; committed size is untouched.
+      expect(store.gridResizePreview()).toEqual({
+        rows: 11,
+        columns: 20,
+        clamped: false,
+      });
+      expect(store.rows()).toBe(8);
+      expect(store.columns()).toBe(16);
+    });
+
+    it('should clamp a shrinking preview to the content floor', () => {
+      placeWidget(6, 10);
+
+      store.previewGridResize(-5, -8);
+
+      expect(store.gridResizePreview()).toEqual({
+        rows: 6,
+        columns: 10,
+        clamped: true,
+      });
+    });
+
+    it('should clear the preview', () => {
+      store.previewGridResize(2, 2);
+      expect(store.gridResizePreview()).not.toBeNull();
+
+      store.clearGridResizePreview();
+      expect(store.gridResizePreview()).toBeNull();
+    });
+  });
+
   describe('setGridCellDimensions', () => {
     it('should update grid cell dimensions', () => {
       store.setGridCellDimensions(100, 50);

--- a/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
+++ b/projects/ngx-dashboard/src/lib/store/__tests__/dashboard-store-grid-config.spec.ts
@@ -212,6 +212,30 @@ describe('DashboardStore - Grid Configuration', () => {
     });
   });
 
+  describe('endGridResize', () => {
+    it('should commit a non-zero delta and clear any active preview', () => {
+      store.previewGridResize(2, 3);
+
+      const result = store.endGridResize(2, 3);
+
+      expect(result).toEqual({ rows: 10, columns: 19, clamped: false });
+      expect(store.rows()).toBe(10);
+      expect(store.columns()).toBe(19);
+      expect(store.gridResizePreview()).toBeNull();
+    });
+
+    it('should return null and clear the preview for a zero delta', () => {
+      store.previewGridResize(0, 0);
+
+      const result = store.endGridResize(0, 0);
+
+      expect(result).toBeNull();
+      expect(store.rows()).toBe(8);
+      expect(store.columns()).toBe(16);
+      expect(store.gridResizePreview()).toBeNull();
+    });
+  });
+
   describe('setGridCellDimensions', () => {
     it('should update grid cell dimensions', () => {
       store.setGridCellDimensions(100, 50);

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -55,6 +55,15 @@ export const DashboardStore = signalStore(
 
   // Cross-feature computed properties (need access to multiple features)
   withComputed((store) => ({
+    // Effective grid size: the live resize preview when a handle drag is in
+    // progress, otherwise the committed size. Consumed wherever the rendered
+    // grid size matters (editor template, outer frame, viewport letterboxing)
+    // so they all reflow together during a drag.
+    effectiveRows: computed(() => store.gridResizePreview()?.rows ?? store.rows()),
+    effectiveColumns: computed(
+      () => store.gridResizePreview()?.columns ?? store.columns()
+    ),
+
     // Invalid zones (collision detection)
     invalidHighlightMap: computed(() => {
       const collisionInfo = calculateCollisionInfo(

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -9,7 +9,10 @@ import {
 import { DashboardService } from '../services/dashboard.service';
 import { inject, computed } from '@angular/core';
 import { calculateCollisionInfo } from './features/utils/collision.utils';
-import { applySelectionFilter } from './features/utils/export.utils';
+import {
+  applySelectionFilter,
+  calculateMinimalBoundingBox,
+} from './features/utils/export.utils';
 import {
   CellId,
   CellIdUtils,
@@ -19,6 +22,7 @@ import {
   UNKNOWN_WIDGET_TYPEID,
   WidgetIdUtils,
   GridSelection,
+  GridResizeResult,
   SelectionFilterOptions,
 } from '../models';
 import { withGridConfig } from './features/grid-config.feature';
@@ -126,6 +130,34 @@ export const DashboardStore = signalStore(
           }
         },
       });
+    },
+
+    // GRID RESIZE (change row/column counts on a populated dashboard)
+    // Clamp-to-content policy: a requested size that would push a widget out
+    // of bounds is snapped up to the smallest size that still contains every
+    // widget's full footprint, so shrinking never orphans a widget.
+    setGridSize(rows: number, columns: number): GridResizeResult {
+      // The bounding box's max edges are the smallest grid that still contains
+      // every widget's full footprint, so they are the shrink floor (a widget
+      // at col 14 spanning 3 columns needs at least 16 columns). null = empty.
+      const bounds = calculateMinimalBoundingBox(store.cells());
+      const minRows = bounds?.maxRow ?? 1;
+      const minColumns = bounds?.maxCol ?? 1;
+
+      const requestedRows = Math.max(1, Math.floor(rows));
+      const requestedColumns = Math.max(1, Math.floor(columns));
+
+      const nextRows = Math.max(minRows, requestedRows);
+      const nextColumns = Math.max(minColumns, requestedColumns);
+
+      store.setGridConfig({ rows: nextRows, columns: nextColumns });
+
+      return {
+        rows: nextRows,
+        columns: nextColumns,
+        clamped:
+          nextRows !== requestedRows || nextColumns !== requestedColumns,
+      };
     },
 
     // EXPORT/IMPORT METHODS (need access to multiple features)

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -294,6 +294,20 @@ export const DashboardStore = signalStore(
     },
   })),
 
+  // End a grid resize gesture atomically (mirrors withResize._endResize):
+  // clear the live preview, no-op on a zero delta, otherwise commit the
+  // relative resize. Separate block so it can call growGrid above.
+  withMethods((store) => ({
+    endGridResize(
+      deltaRows: number,
+      deltaColumns: number
+    ): GridResizeResult | null {
+      store.clearGridResizePreview();
+      if (deltaRows === 0 && deltaColumns === 0) return null;
+      return store.growGrid(deltaRows, deltaColumns);
+    },
+  })),
+
   // Cross-feature computed properties that depend on resize + widget data (using utility functions)
   withComputed((store) => ({
     // Compute preview cells during resize using utility function

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -281,22 +281,13 @@ export const DashboardStore = signalStore(
     },
   })),
 
-  // Relative grid resize. Split into its own block so it can call the
-  // absolute setGridSize defined above (siblings in one withMethods block
-  // aren't visible to each other). Keeps the base-read and clamp together in
-  // the store rather than having callers compute the absolute target.
-  withMethods((store) => ({
-    growGrid(deltaRows: number, deltaColumns: number): GridResizeResult {
-      return store.setGridSize(
-        store.rows() + deltaRows,
-        store.columns() + deltaColumns
-      );
-    },
-  })),
-
   // End a grid resize gesture atomically (mirrors withResize._endResize):
   // clear the live preview, no-op on a zero delta, otherwise commit the
-  // relative resize. Separate block so it can call growGrid above.
+  // relative resize. Returns null (no committed change) when the delta is zero
+  // or clamp-to-content leaves the size unchanged, so callers don't signal a
+  // resize that did nothing. Split into its own block so it can call the
+  // absolute setGridSize above (siblings in one withMethods block aren't
+  // visible to each other).
   withMethods((store) => ({
     endGridResize(
       deltaRows: number,
@@ -304,7 +295,17 @@ export const DashboardStore = signalStore(
     ): GridResizeResult | null {
       store.clearGridResizePreview();
       if (deltaRows === 0 && deltaColumns === 0) return null;
-      return store.growGrid(deltaRows, deltaColumns);
+
+      const beforeRows = store.rows();
+      const beforeColumns = store.columns();
+      const result = store.setGridSize(
+        beforeRows + deltaRows,
+        beforeColumns + deltaColumns
+      );
+      if (result.rows === beforeRows && result.columns === beforeColumns) {
+        return null;
+      }
+      return result;
     },
   })),
 

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -9,10 +9,8 @@ import {
 import { DashboardService } from '../services/dashboard.service';
 import { inject, computed } from '@angular/core';
 import { calculateCollisionInfo } from './features/utils/collision.utils';
-import {
-  applySelectionFilter,
-  calculateMinimalBoundingBox,
-} from './features/utils/export.utils';
+import { applySelectionFilter } from './features/utils/export.utils';
+import { clampGridSize } from './features/utils/grid-resize.utils';
 import {
   CellId,
   CellIdUtils,
@@ -29,6 +27,7 @@ import { withGridConfig } from './features/grid-config.feature';
 import { withWidgetManagement } from './features/widget-management.feature';
 import { withDragDrop } from './features/drag-drop.feature';
 import { withResize, ResizePreviewUtils } from './features/resize.feature';
+import { withGridResize } from './features/grid-resize.feature';
 
 /** Returns the intended widget type ID, falling back to the factory's type ID */
 function effectiveWidgetTypeid(cell: CellData): string {
@@ -51,6 +50,7 @@ export const DashboardStore = signalStore(
   withGridConfig(),
   withWidgetManagement(),
   withResize(),
+  withGridResize(),
   withDragDrop(),
 
   // Cross-feature computed properties (need access to multiple features)
@@ -137,27 +137,19 @@ export const DashboardStore = signalStore(
     // of bounds is snapped up to the smallest size that still contains every
     // widget's full footprint, so shrinking never orphans a widget.
     setGridSize(rows: number, columns: number): GridResizeResult {
-      // The bounding box's max edges are the smallest grid that still contains
-      // every widget's full footprint, so they are the shrink floor (a widget
-      // at col 14 spanning 3 columns needs at least 16 columns). null = empty.
-      const bounds = calculateMinimalBoundingBox(store.cells());
-      const minRows = bounds?.maxRow ?? 1;
-      const minColumns = bounds?.maxCol ?? 1;
+      const result = clampGridSize(rows, columns, store.cells());
+      store.setGridConfig({ rows: result.rows, columns: result.columns });
+      return result;
+    },
 
-      const requestedRows = Math.max(1, Math.floor(rows));
-      const requestedColumns = Math.max(1, Math.floor(columns));
-
-      const nextRows = Math.max(minRows, requestedRows);
-      const nextColumns = Math.max(minColumns, requestedColumns);
-
-      store.setGridConfig({ rows: nextRows, columns: nextColumns });
-
-      return {
-        rows: nextRows,
-        columns: nextColumns,
-        clamped:
-          nextRows !== requestedRows || nextColumns !== requestedColumns,
-      };
+    // Preview a relative grid resize during a handle drag (no commit). Stores
+    // the clamped target in gridResizePreview so the editor can live-reflow.
+    previewGridResize(deltaRows: number, deltaColumns: number) {
+      store._previewGridResize(deltaRows, deltaColumns, {
+        rows: store.rows(),
+        columns: store.columns(),
+        cells: store.cells(),
+      });
     },
 
     // EXPORT/IMPORT METHODS (need access to multiple features)

--- a/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
+++ b/projects/ngx-dashboard/src/lib/store/dashboard-store.ts
@@ -289,6 +289,19 @@ export const DashboardStore = signalStore(
     },
   })),
 
+  // Relative grid resize. Split into its own block so it can call the
+  // absolute setGridSize defined above (siblings in one withMethods block
+  // aren't visible to each other). Keeps the base-read and clamp together in
+  // the store rather than having callers compute the absolute target.
+  withMethods((store) => ({
+    growGrid(deltaRows: number, deltaColumns: number): GridResizeResult {
+      return store.setGridSize(
+        store.rows() + deltaRows,
+        store.columns() + deltaColumns
+      );
+    },
+  })),
+
   // Cross-feature computed properties that depend on resize + widget data (using utility functions)
   withComputed((store) => ({
     // Compute preview cells during resize using utility function

--- a/projects/ngx-dashboard/src/lib/store/features/drag-drop.feature.ts
+++ b/projects/ngx-dashboard/src/lib/store/features/drag-drop.feature.ts
@@ -34,6 +34,10 @@ export const withDragDrop = () =>
   signalStoreFeature(
     withState<DragDropState>(initialDragDropState),
     withComputed((store) => ({
+      // True while any widget drag is in progress. Shared by components that
+      // need to suppress conflicting affordances during a drag.
+      isDragActive: computed(() => !!store.dragData()),
+
       // Highlighted zones during drag
       highlightedZones: computed(() =>
         calculateHighlightedZones(store.dragData(), store.hoveredDropZone()),

--- a/projects/ngx-dashboard/src/lib/store/features/grid-resize.feature.ts
+++ b/projects/ngx-dashboard/src/lib/store/features/grid-resize.feature.ts
@@ -21,8 +21,9 @@ export const withGridResize = () =>
     withState<GridResizeState>(initialGridResizeState),
     withMethods((store) => ({
       // Needs cross-feature dependencies (current size + cells for the floor),
-      // injected by the store wrapper. Skips the patch when nothing changed so
-      // sub-cell pointer movement doesn't trigger redundant grid re-renders.
+      // injected by the store wrapper. Skips the patch when the clamped result
+      // is unchanged — e.g. dragging further past the content floor yields new
+      // raw deltas but the same clamped preview — avoiding redundant re-renders.
       _previewGridResize(
         deltaRows: number,
         deltaColumns: number,

--- a/projects/ngx-dashboard/src/lib/store/features/grid-resize.feature.ts
+++ b/projects/ngx-dashboard/src/lib/store/features/grid-resize.feature.ts
@@ -1,0 +1,56 @@
+import {
+  signalStoreFeature,
+  withMethods,
+  withState,
+  patchState,
+} from '@ngrx/signals';
+import { CellData, GridResizeResult } from '../../models';
+import { clampGridSize } from './utils/grid-resize.utils';
+
+export interface GridResizeState {
+  /** Previewed (clamped) grid size during a handle drag; null when idle. */
+  gridResizePreview: GridResizeResult | null;
+}
+
+const initialGridResizeState: GridResizeState = {
+  gridResizePreview: null,
+};
+
+export const withGridResize = () =>
+  signalStoreFeature(
+    withState<GridResizeState>(initialGridResizeState),
+    withMethods((store) => ({
+      // Needs cross-feature dependencies (current size + cells for the floor),
+      // injected by the store wrapper. Skips the patch when nothing changed so
+      // sub-cell pointer movement doesn't trigger redundant grid re-renders.
+      _previewGridResize(
+        deltaRows: number,
+        deltaColumns: number,
+        dependencies: { rows: number; columns: number; cells: CellData[] }
+      ) {
+        const preview = clampGridSize(
+          dependencies.rows + deltaRows,
+          dependencies.columns + deltaColumns,
+          dependencies.cells
+        );
+
+        const current = store.gridResizePreview();
+        if (
+          current &&
+          current.rows === preview.rows &&
+          current.columns === preview.columns &&
+          current.clamped === preview.clamped
+        ) {
+          return;
+        }
+
+        patchState(store, { gridResizePreview: preview });
+      },
+
+      clearGridResizePreview() {
+        if (store.gridResizePreview() !== null) {
+          patchState(store, { gridResizePreview: null });
+        }
+      },
+    }))
+  );

--- a/projects/ngx-dashboard/src/lib/store/features/utils/grid-resize.utils.ts
+++ b/projects/ngx-dashboard/src/lib/store/features/utils/grid-resize.utils.ts
@@ -1,0 +1,34 @@
+import { CellData, GridResizeResult } from '../../../models';
+import { calculateMinimalBoundingBox } from './export.utils';
+
+/**
+ * Clamp a requested grid size to the smallest size that still contains every
+ * widget's full footprint (the content floor). Pure: computes the result but
+ * does not mutate any state, so it is shared by both the committed resize
+ * (`setGridSize`) and the in-progress drag preview.
+ *
+ * Values below 1 are treated as 1; fractional values are floored.
+ */
+export function clampGridSize(
+  requestedRows: number,
+  requestedColumns: number,
+  cells: CellData[]
+): GridResizeResult {
+  // The bounding box's max edges are span-aware (a widget at col 14 spanning
+  // 3 columns needs at least 16 columns). null = empty dashboard.
+  const bounds = calculateMinimalBoundingBox(cells);
+  const minRows = bounds?.maxRow ?? 1;
+  const minColumns = bounds?.maxCol ?? 1;
+
+  const reqRows = Math.max(1, Math.floor(requestedRows));
+  const reqColumns = Math.max(1, Math.floor(requestedColumns));
+
+  const rows = Math.max(minRows, reqRows);
+  const columns = Math.max(minColumns, reqColumns);
+
+  return {
+    rows,
+    columns,
+    clamped: rows !== reqRows || columns !== reqColumns,
+  };
+}

--- a/projects/ngx-dashboard/src/lib/store/features/utils/grid-resize.utils.ts
+++ b/projects/ngx-dashboard/src/lib/store/features/utils/grid-resize.utils.ts
@@ -1,6 +1,11 @@
 import { CellData, GridResizeResult } from '../../../models';
 import { calculateMinimalBoundingBox } from './export.utils';
 
+/** Floor a requested track count to a positive integer; non-finite -> 1. */
+function sanitizeRequest(value: number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.floor(value)) : 1;
+}
+
 /**
  * Clamp a requested grid size to the smallest size that still contains every
  * widget's full footprint (the content floor). Pure: computes the result but
@@ -20,8 +25,11 @@ export function clampGridSize(
   const minRows = bounds?.maxRow ?? 1;
   const minColumns = bounds?.maxCol ?? 1;
 
-  const reqRows = Math.max(1, Math.floor(requestedRows));
-  const reqColumns = Math.max(1, Math.floor(requestedColumns));
+  // Sanitize non-finite input (NaN/Infinity from e.g. parseInt of empty user
+  // input) to 1 so it can never reach committed grid state; clamp-to-content
+  // then floors it at the occupied extent.
+  const reqRows = sanitizeRequest(requestedRows);
+  const reqColumns = sanitizeRequest(requestedColumns);
 
   const rows = Math.max(minRows, reqRows);
   const columns = Math.max(minColumns, reqColumns);

--- a/projects/ngx-dashboard/src/lib/styles/_resize-cursors.scss
+++ b/projects/ngx-dashboard/src/lib/styles/_resize-cursors.scss
@@ -1,0 +1,17 @@
+/*
+ * Global body cursor classes applied imperatively (via Renderer2) to
+ * document.body for the duration of a drag-resize gesture. Shared by the cell
+ * resize handle and the grid resize handle so the classes have a single source
+ * of truth rather than being duplicated in each component's stylesheet.
+ */
+:root .cursor-col-resize {
+  cursor: col-resize !important;
+}
+
+:root .cursor-row-resize {
+  cursor: row-resize !important;
+}
+
+:root .cursor-nwse-resize {
+  cursor: nwse-resize !important;
+}

--- a/projects/ngx-dashboard/src/public-api.ts
+++ b/projects/ngx-dashboard/src/public-api.ts
@@ -11,6 +11,7 @@ export { WidgetListComponent } from './lib/widget-list/widget-list.component';
 
 // Dashboard viewer types (for selection feature)
 export type { GridSelection } from './lib/models/grid-selection';
+export type { GridResizeResult } from './lib/models/grid-resize-result';
 export type { SelectionFilterOptions } from './lib/models/selection-filter-options';
 export type { SelectionModifier } from './lib/models/selection-modifier';
 


### PR DESCRIPTION
## Resizable dashboard grid in the editor

Adds the ability to resize an existing, populated dashboard's grid (row/column counts) from the editor — both via a public API and via interactive drag handles with a live preview.

### What's included

**Public API (new, backward-compatible)**
- `DashboardComponent.setGridSize(rows, columns): GridResizeResult` — imperative resize.
- `gridResized` output — emitted (only on an actual change) by both the imperative call and the drag handles.
- `GridResizeResult` type (`{ rows, columns, clamped }`), exported.

**Editor drag handles**
- Right / bottom / corner `lib-grid-resize-handle`s, built into the editor (appear automatically in edit mode).
- **Live preview**: the grid reflows under the handle as you drag (fit-to-fill — cells resize, no commit until release), with added tracks tinted and a live `columns × rows` size badge.
- **Clamp-to-content**: shrinking can never orphan a widget — the size snaps up to the smallest grid that still contains every widget's footprint (badge turns red at the floor).

### Design notes
- **Clamp-to-content** is the shrink policy (no widget is ever orphaned); non-finite requests are sanitized.
- **Fit-to-fill, both axes**: the frame letterboxes to the previewed size within the available space, so growing rows *or* columns shrinks the cells to fit rather than producing a scrollbar.
- **PointerEvents + capture**: handles work with mouse, touch and pen; `pointercancel` / `window:blur` abort cleanly (no leaked listeners, cursor, or phantom commit). The px→track divisor is snapshotted at gesture start to avoid feedback overshoot.
- Square-cell geometry is preserved — handles live in the existing gutter, so no reserved band was needed.

### Quality
- Built incrementally (API → live preview → hardening → fit fix), each step run through `/simplify` and reviewed.
- Two end-to-end **xhigh** `/code-review` passes; all surfaced findings fixed.
- `ngx-dashboard` 523 tests, `demo` 33 tests, lint clean, AOT (ng-packagr) build clean.

### Housekeeping in this PR
- `chore(i18n)`: re-extracted demo catalogs (adds the grid-resize badge string + previously-unextracted strings).
- `chore(release)`: minor bump of both libs to **22.1.0** (lockstep) for the new API.
- `chore`: `.gitignore` tidy for local tooling files.

### Deferred (not blocking)
- No maximum row/column cap is imposed on finite requests (a product decision); non-finite input is already guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
