### PR TITLE
feat: add widget groups

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -328,6 +328,25 @@ export class DashboardPageComponent {
 </div>
 ```
 
+### Widget List Options
+
+```html
+<ngx-dashboard-widget-list
+  class="widget-list"
+  [collapsed]="isWidgetListCollapsed()"
+  [enableSearchBox]="true"
+></ngx-dashboard-widget-list>
+```
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `collapsed` | `false` | Renders the list as an icon-only rail. Names, descriptions and the search box are hidden; each widget keeps a tooltip. |
+| `enableSearchBox` | `false` | Shows a free-text filter above the list, matching widget name, description and widget type id (case insensitive) |
+
+Widgets are grouped by their optional `WidgetMetadata.group`; grouped sections
+can be collapsed, and ungrouped widgets are listed last. While a filter is
+active every group stays expanded so matches are never hidden.
+
 ## Widget Registration
 
 ### Built-in Widgets

--- a/USAGE.md
+++ b/USAGE.md
@@ -335,13 +335,23 @@ export class DashboardPageComponent {
   class="widget-list"
   [collapsed]="isWidgetListCollapsed()"
   [enableSearchBox]="true"
+  [enableGutterSlider]="true"
 ></ngx-dashboard-widget-list>
 ```
 
 | Input | Default | Description |
 | --- | --- | --- |
-| `collapsed` | `false` | Renders the list as an icon-only rail. Names, descriptions and the search box are hidden; each widget keeps a tooltip. |
+| `collapsed` | `false` | Renders the list as an icon-only rail. Names, descriptions, the search box and the gutter slider are hidden; each widget keeps a tooltip. |
 | `enableSearchBox` | `false` | Shows a free-text filter above the list, matching widget name, description and widget type id (case insensitive) |
+| `enableGutterSlider` | `false` | Docks a slider to the list's bottom-left corner that drives the dashboard's gutter size |
+
+The gutter slider floats over the list and sticks to its bottom-left corner, so
+it stays reachable however long the list runs. It applies to the first
+registered dashboard — the same one widgets are dragged onto — and writes
+through on every input, so the grid reflows under the thumb. It keeps the unit
+the dashboard already uses (`px` 0–48, `em`/`rem` 0–3); a gutter authored in any
+other unit (`%`, `calc()`) falls back to the `0.5em` default. The slider is
+hidden until a dashboard registers, and in the icon-only rail.
 
 Widgets are grouped by their optional `WidgetMetadata.group`; grouped sections
 can be collapsed, and ungrouped widgets are listed last. While a filter is

--- a/USAGE.md
+++ b/USAGE.md
@@ -504,6 +504,7 @@ export class MyWidgetComponent implements Widget {
     name: 'My Custom Widget',          // Display name in widget list
     description: 'A sample custom widget with counter functionality',
     svgIcon,                          // Widget icon for widget list
+    group: 'Custom',                  // Optional widget list heading
   };
 
   private readonly sanitizer = inject(DomSanitizer);

--- a/docs/widget-system-architecture.md
+++ b/docs/widget-system-architecture.md
@@ -7,7 +7,8 @@
   - `dashboardGetState()` - retrieves current widget state
   - `dashboardSetState(state)` - sets widget state
   - `dashboardEditState()` - opens widget configuration dialog
-- `WidgetMetadata` with unique `widgetTypeid`, name, description, and SVG icon
+- `WidgetMetadata` with unique `widgetTypeid`, name, description, SVG icon, and an
+  optional `group` heading used by the widget list
 - `WidgetComponentClass<T>` extends Angular's `Type<T>` with static `metadata` property
 
 ### 2. DashboardService (`services/dashboard.service.ts`)

--- a/docs/widget-system-architecture.md
+++ b/docs/widget-system-architecture.md
@@ -8,7 +8,10 @@
   - `dashboardSetState(state)` - sets widget state
   - `dashboardEditState()` - opens widget configuration dialog
 - `WidgetMetadata` with unique `widgetTypeid`, name, description, SVG icon, and an
-  optional `group` heading used by the widget list
+  optional `group` heading used by the widget list. Grouped widgets render inside a
+  collapsible `mat-expansion-panel`; ungrouped widgets trail them behind a divider.
+  In the icon-only rail there is no room for headings, so sections are separated by
+  dividers only and cannot be collapsed.
 - `WidgetComponentClass<T>` extends Angular's `Type<T>` with static `metadata` property
 
 ### 2. DashboardService (`services/dashboard.service.ts`)

--- a/projects/demo/src/app/app.html
+++ b/projects/demo/src/app/app.html
@@ -1,7 +1,11 @@
 <mat-toolbar class="toolbar">
   <!-- Left side navigation -->
   <div class="toolbar-left">
-    <button mat-button [matMenuTriggerFor]="navigationMenu">
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="navigationMenu"
+      [attr.aria-label]="getNavigationMenuAriaLabel()"
+    >
       <mat-icon>menu</mat-icon>
     </button>
     <mat-menu #navigationMenu="matMenu">
@@ -52,35 +56,31 @@
     >
       <mat-icon>format_color_fill</mat-icon>
     </button>
-    <mat-menu #themeMenu="matMenu">
-      <mat-radio-group
-        [value]="themeService.theme()"
-        (change)="setTheme($event.value)"
-        class="theme-radio-group"
+    <mat-menu #themeMenu="matMenu" class="theme-menu">
+      <!-- Menu items rather than radios in a bare div: they bring the menu's own
+           hover, focus and ripple surfaces, which hand-rolled rows lacked. -->
+      @for (themeConfig of themeService.availableThemes(); track
+      themeConfig.key) {
+      <button
+        mat-menu-item
+        role="menuitemradio"
+        class="theme-option"
+        (click)="setTheme(themeConfig.key)"
+        [attr.aria-checked]="themeService.theme() === themeConfig.key"
+        [attr.aria-label]="getThemeOptionAriaLabel(themeConfig.displayName)"
       >
-        @for (themeConfig of themeService.availableThemes(); track
-        themeConfig.key) {
-        <div
-          class="theme-option-row"
-          (click)="setTheme(themeConfig.key)"
-          (keyup.enter)="setTheme(themeConfig.key)"
-          (keyup.space)="setTheme(themeConfig.key)"
-          tabindex="0"
-          role="button"
-          [attr.aria-label]="getThemeOptionAriaLabel(themeConfig.displayName)"
-        >
-          <mat-radio-button [value]="themeConfig.key" class="theme-option">
-            {{ themeConfig.displayName }}
-          </mat-radio-button>
-          <div
-            class="color-swatch"
-            [style.background-color]="'var(' + themeConfig.cssVariable + ')'"
-            [style.border]="'1px solid var(' + themeConfig.cssVariable + ')'"
-            [style.border]="'1px solid black'"
-          ></div>
-        </div>
-        }
-      </mat-radio-group>
+        <mat-icon>{{
+          themeService.theme() === themeConfig.key
+            ? "radio_button_checked"
+            : "radio_button_unchecked"
+        }}</mat-icon>
+        <span class="theme-option-name">{{ themeConfig.displayName }}</span>
+        <span
+          class="color-swatch"
+          [style.background-color]="'var(' + themeConfig.cssVariable + ')'"
+        ></span>
+      </button>
+      }
     </mat-menu>
 
     <!-- Dark/Light mode toggle -->

--- a/projects/demo/src/app/app.scss
+++ b/projects/demo/src/app/app.scss
@@ -43,19 +43,6 @@
   white-space: nowrap;
 }
 
-/* Navigation menu button */
-button[matMenuTriggerFor="navigationMenu"] {
-  display: flex !important;
-  align-items: center;
-  gap: 4px;
-
-  mat-icon {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-  }
-}
-
 /* Theme selector button */
 .theme-selector {
   display: flex;
@@ -111,28 +98,6 @@ mat-icon {
   }
 }
 
-/* General menu trigger buttons */
-button[matMenuTriggerFor] {
-  display: flex !important;
-  align-items: center;
-  gap: 4px;
-
-  mat-icon {
-    font-size: 20px;
-    width: 20px;
-    height: 20px;
-  }
-}
-
-/* Button hover states */
-.toolbar button {
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background-color: var(--mat-sys-surface-container-high);
-  }
-}
-
 /* Edit toggle button - fixed width to prevent title shifting */
 .edit-toggle {
   width: 100px;
@@ -162,63 +127,30 @@ body.dark-mode {
   }
 }
 
-/* Theme radio group - compact vertical layout with swatches */
-.theme-radio-group {
-  display: flex;
-  flex-direction: column;
-  padding: 4px 0;
-}
-
-.theme-option-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 2px 12px;
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--mat-sys-surface-container-high);
+/* Theme picker rows: icon, name, then the palette swatch on the trailing edge */
+.theme-option {
+  .theme-option-name {
+    flex: 1;
   }
 
-  // Selected state styling
-  &:has(.theme-option.mat-mdc-radio-checked) {
-    background-color: var(--mat-sys-primary-container);
+  &[aria-checked="true"] {
+    color: var(--mat-sys-primary);
 
-    .theme-option {
-      color: var(--mat-sys-on-primary-container);
-
-      ::ng-deep .mdc-form-field label {
-        color: var(--mat-sys-on-primary-container);
-        font-weight: 500;
-      }
+    .mat-icon {
+      color: var(--mat-sys-primary);
     }
   }
 }
 
-.theme-option {
-  flex-grow: 1;
-
-  ::ng-deep .mdc-form-field {
-    padding: 4px 0;
-    margin: 0;
-  }
-
-  ::ng-deep .mdc-radio {
-    padding: 6px;
-  }
-
-  ::ng-deep .mdc-form-field label {
-    font-size: 14px;
-    color: var(--mat-sys-on-surface);
-  }
-}
-
 .color-swatch {
+  display: inline-block;
   width: 24px;
   height: 16px;
   border-radius: 4px;
   flex-shrink: 0;
   margin-left: 12px;
+  // Pale swatches would otherwise vanish into the menu surface.
+  border: 1px solid var(--mat-sys-outline-variant);
 }
 
 /* Version info display */

--- a/projects/demo/src/app/app.ts
+++ b/projects/demo/src/app/app.ts
@@ -4,7 +4,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
-import { MatRadioModule } from '@angular/material/radio';
 import { NGX_DASHBOARD_VERSION } from '@dragonworks/ngx-dashboard';
 import { NGX_DASHBOARD_WIDGETS_VERSION } from '@dragonworks/ngx-dashboard-widgets';
 import { ThemeService, type ThemePalette } from './services';
@@ -18,7 +17,6 @@ import { ThemeService, type ThemePalette } from './services';
     MatToolbarModule,
     MatMenuModule,
     MatIconModule,
-    MatRadioModule,
   ],
   providers: [],
   templateUrl: './app.html',
@@ -42,6 +40,13 @@ export class App {
     return this.themeService.isDarkMode()
       ? $localize`:@@demo.theme.switchToLight:Switch to light theme`
       : $localize`:@@demo.theme.switchToDark:Switch to dark theme`;
+  }
+
+  /**
+   * Get navigation menu aria label
+   */
+  getNavigationMenuAriaLabel(): string {
+    return $localize`:@@demo.navigation.menuAriaLabel:Open navigation menu`;
   }
 
   /**

--- a/projects/demo/src/app/components/dashboard/dashboard.component.html
+++ b/projects/demo/src/app/components/dashboard/dashboard.component.html
@@ -46,6 +46,7 @@
       class="widget-list"
       [collapsed]="isWidgetListCollapsed()"
       [enableSearchBox]="true"
+      [enableGutterSlider]="true"
     ></ngx-dashboard-widget-list>
   </div>
   }

--- a/projects/demo/src/app/components/dashboard/dashboard.component.html
+++ b/projects/demo/src/app/components/dashboard/dashboard.component.html
@@ -34,14 +34,18 @@
       i18n-matTooltip="@@demo.dashboard.toggleWidgetListHeader"
       matTooltipPosition="left"
     >
-      <mat-icon class="widgets-icon">dashboard</mat-icon>
       @if (!isWidgetListCollapsed()) {
+      <mat-icon class="widgets-icon">dashboard</mat-icon>
       <span class="widgets-title" i18n="@@demo.dashboard.widgetsTitle">Widgets</span>
       }
+      <mat-icon class="toggle-icon">{{
+        isWidgetListCollapsed() ? 'chevron_left' : 'chevron_right'
+      }}</mat-icon>
     </div>
     <ngx-dashboard-widget-list
       class="widget-list"
       [collapsed]="isWidgetListCollapsed()"
+      [enableSearchBox]="true"
     ></ngx-dashboard-widget-list>
   </div>
   }

--- a/projects/demo/src/app/components/dashboard/dashboard.component.scss
+++ b/projects/demo/src/app/components/dashboard/dashboard.component.scss
@@ -52,7 +52,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 16px 16px 8px;
+    padding: 12px 12px 12px 16px;
     border-bottom: 1px solid var(--mat-sys-outline-variant);
     transition: all 300ms var(--mat-sys-motion-easing-standard);
     cursor: pointer;
@@ -66,12 +66,9 @@
         transparent
       );
 
-      .widgets-icon {
-        color: var(--mat-sys-primary);
-        transform: scale(1.1);
-      }
-
-      .widgets-title {
+      .widgets-icon,
+      .widgets-title,
+      .toggle-icon {
         color: var(--mat-sys-primary);
       }
     }
@@ -89,11 +86,20 @@
       );
     }
 
-    .widgets-icon {
+    .widgets-icon,
+    .toggle-icon {
       color: var(--mat-sys-on-surface-variant);
-      transition: all 200ms ease;
+      transition: color 200ms ease;
     }
 
+    .toggle-icon {
+      font-size: 28px;
+      width: 28px;
+      height: 28px;
+      line-height: 28px;
+    }
+
+    // Pushes the chevron to the panel edge it collapses toward.
     .widgets-title {
       flex: 1;
       font-size: var(--mat-sys-title-small-size);
@@ -110,11 +116,7 @@
 
     .widget-list-header {
       justify-content: center;
-      padding: 16px 8px 8px;
-
-      .widgets-icon {
-        transform: scale(1.1);
-      }
+      padding: 12px 8px;
     }
 
     .widget-list {

--- a/projects/demo/src/app/widgets/realtime-gauge-widget/realtime-gauge-widget.component.ts
+++ b/projects/demo/src/app/widgets/realtime-gauge-widget/realtime-gauge-widget.component.ts
@@ -47,6 +47,7 @@ export class RealtimeGaugeWidgetComponent implements Widget {
     name: $localize`:@@demo.widgets.realtimeGauge.name:Realtime Gauge`,
     description: $localize`:@@demo.widgets.realtimeGauge.description:Gauge with real-time data updates`,
     svgIcon,
+    group: $localize`:@@demo.widgets.group.sensors:Sensors`,
   };
 
   readonly #dialog = inject(MatDialog);

--- a/projects/demo/src/app/widgets/sparkbar-widget/sparkbar-widget.component.ts
+++ b/projects/demo/src/app/widgets/sparkbar-widget/sparkbar-widget.component.ts
@@ -40,6 +40,7 @@ export class SparkbarWidgetComponent implements Widget {
     name: $localize`:@@demo.widgets.sparkbar.name:Sparkbar`,
     description: $localize`:@@demo.widgets.sparkbar.description:A sparkbar graph`,
     svgIcon,
+    group: $localize`:@@demo.widgets.group.charts:Charts`,
   };
 
   readonly #sanitizer = inject(DomSanitizer);

--- a/projects/demo/src/app/widgets/sparkline-widget/sparkline-widget.component.ts
+++ b/projects/demo/src/app/widgets/sparkline-widget/sparkline-widget.component.ts
@@ -39,6 +39,7 @@ export class SparklineWidgetComponent implements Widget {
     name: $localize`:@@demo.widgets.sparkline.name:Sparkline`,
     description: $localize`:@@demo.widgets.sparkline.description:A sparkline graph`,
     svgIcon,
+    group: $localize`:@@demo.widgets.group.charts:Charts`,
   };
 
   readonly #sanitizer = inject(DomSanitizer);

--- a/projects/demo/src/app/widgets/temperature-widget/temperature-widget.component.ts
+++ b/projects/demo/src/app/widgets/temperature-widget/temperature-widget.component.ts
@@ -37,6 +37,7 @@ export class TemperatureWidgetComponent implements Widget {
     name: $localize`:@@demo.widgets.temperature.name:Temperature`,
     description: $localize`:@@demo.widgets.temperature.description:Display a temperature value`,
     svgIcon,
+    group: $localize`:@@demo.widgets.group.sensors:Sensors`,
   };
 
   readonly #sanitizer = inject(DomSanitizer);

--- a/projects/demo/src/locale/messages.de.xlf
+++ b/projects/demo/src/locale/messages.de.xlf
@@ -907,6 +907,18 @@
         <target>Realtime Gauge</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.group.charts">
+      <segment state="initial">
+        <source>Charts</source>
+        <target>Charts</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.group.sensors">
+      <segment state="initial">
+        <source>Sensors</source>
+        <target>Sensors</target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.realtimeGauge.description">
       <segment state="initial">
         <source>Gauge with real-time data updates</source>
@@ -1311,8 +1323,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1527,8 +1539,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">

--- a/projects/demo/src/locale/messages.de.xlf
+++ b/projects/demo/src/locale/messages.de.xlf
@@ -1813,6 +1813,18 @@
         <target>Available widgets</target>
       </segment>
     </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.ariaLabel">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.tooltip">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
     <unit id="ngx.dashboard.widget.list.item.ariaLabel">
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>

--- a/projects/demo/src/locale/messages.de.xlf
+++ b/projects/demo/src/locale/messages.de.xlf
@@ -7,6 +7,12 @@
         <target>Dashboard</target>
       </segment>
     </unit>
+    <unit id="demo.navigation.menuAriaLabel">
+      <segment state="initial">
+        <source>Open navigation menu</source>
+        <target>Open navigation menu</target>
+      </segment>
+    </unit>
     <unit id="demo.navigation.radialGaugeDemo">
       <segment state="initial">
         <source>Radial Gauge Demo</source>
@@ -1323,8 +1329,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1539,8 +1545,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">
@@ -1811,6 +1817,30 @@
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>
         <target><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.ariaLabel">
+      <segment state="initial">
+        <source>Search widgets by name, description or type</source>
+        <target>Search widgets by name, description or type</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.clear">
+      <segment state="initial">
+        <source>Clear widget search</source>
+        <target>Clear widget search</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.empty">
+      <segment state="initial">
+        <source> No matching widgets </source>
+        <target> No matching widgets </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.placeholder">
+      <segment state="initial">
+        <source>Search widgets</source>
+        <target>Search widgets</target>
       </segment>
     </unit>
   </file>

--- a/projects/demo/src/locale/messages.es.xlf
+++ b/projects/demo/src/locale/messages.es.xlf
@@ -907,6 +907,18 @@
         <target>Realtime Gauge</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.group.charts">
+      <segment state="initial">
+        <source>Charts</source>
+        <target>Charts</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.group.sensors">
+      <segment state="initial">
+        <source>Sensors</source>
+        <target>Sensors</target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.realtimeGauge.description">
       <segment state="initial">
         <source>Gauge with real-time data updates</source>
@@ -1311,8 +1323,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1527,8 +1539,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">

--- a/projects/demo/src/locale/messages.es.xlf
+++ b/projects/demo/src/locale/messages.es.xlf
@@ -1813,6 +1813,18 @@
         <target>Available widgets</target>
       </segment>
     </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.ariaLabel">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.tooltip">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
     <unit id="ngx.dashboard.widget.list.item.ariaLabel">
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>

--- a/projects/demo/src/locale/messages.es.xlf
+++ b/projects/demo/src/locale/messages.es.xlf
@@ -7,6 +7,12 @@
         <target>Dashboard</target>
       </segment>
     </unit>
+    <unit id="demo.navigation.menuAriaLabel">
+      <segment state="initial">
+        <source>Open navigation menu</source>
+        <target>Open navigation menu</target>
+      </segment>
+    </unit>
     <unit id="demo.navigation.radialGaugeDemo">
       <segment state="initial">
         <source>Radial Gauge Demo</source>
@@ -1323,8 +1329,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1539,8 +1545,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">
@@ -1811,6 +1817,30 @@
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>
         <target><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.ariaLabel">
+      <segment state="initial">
+        <source>Search widgets by name, description or type</source>
+        <target>Search widgets by name, description or type</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.clear">
+      <segment state="initial">
+        <source>Clear widget search</source>
+        <target>Clear widget search</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.empty">
+      <segment state="initial">
+        <source> No matching widgets </source>
+        <target> No matching widgets </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.placeholder">
+      <segment state="initial">
+        <source>Search widgets</source>
+        <target>Search widgets</target>
       </segment>
     </unit>
   </file>

--- a/projects/demo/src/locale/messages.fr.xlf
+++ b/projects/demo/src/locale/messages.fr.xlf
@@ -907,6 +907,18 @@
         <target>Realtime Gauge</target>
       </segment>
     </unit>
+    <unit id="demo.widgets.group.charts">
+      <segment state="initial">
+        <source>Charts</source>
+        <target>Charts</target>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.group.sensors">
+      <segment state="initial">
+        <source>Sensors</source>
+        <target>Sensors</target>
+      </segment>
+    </unit>
     <unit id="demo.widgets.realtimeGauge.description">
       <segment state="initial">
         <source>Gauge with real-time data updates</source>
@@ -1311,8 +1323,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1527,8 +1539,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">

--- a/projects/demo/src/locale/messages.fr.xlf
+++ b/projects/demo/src/locale/messages.fr.xlf
@@ -1813,6 +1813,18 @@
         <target>Available widgets</target>
       </segment>
     </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.ariaLabel">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.tooltip">
+      <segment state="initial">
+        <source>Gutter size between dashboard cells</source>
+        <target>Gutter size between dashboard cells</target>
+      </segment>
+    </unit>
     <unit id="ngx.dashboard.widget.list.item.ariaLabel">
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>

--- a/projects/demo/src/locale/messages.fr.xlf
+++ b/projects/demo/src/locale/messages.fr.xlf
@@ -7,6 +7,12 @@
         <target>Dashboard</target>
       </segment>
     </unit>
+    <unit id="demo.navigation.menuAriaLabel">
+      <segment state="initial">
+        <source>Open navigation menu</source>
+        <target>Open navigation menu</target>
+      </segment>
+    </unit>
     <unit id="demo.navigation.radialGaugeDemo">
       <segment state="initial">
         <source>Radial Gauge Demo</source>
@@ -1323,8 +1329,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1539,8 +1545,8 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment state="initial">
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
-        <target> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </target>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <target> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </target>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">
@@ -1811,6 +1817,30 @@
       <segment state="initial">
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>
         <target><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.ariaLabel">
+      <segment state="initial">
+        <source>Search widgets by name, description or type</source>
+        <target>Search widgets by name, description or type</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.clear">
+      <segment state="initial">
+        <source>Clear widget search</source>
+        <target>Clear widget search</target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.empty">
+      <segment state="initial">
+        <source> No matching widgets </source>
+        <target> No matching widgets </target>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.placeholder">
+      <segment state="initial">
+        <source>Search widgets</source>
+        <target>Search widgets</target>
       </segment>
     </unit>
   </file>

--- a/projects/demo/src/locale/messages.xlf
+++ b/projects/demo/src/locale/messages.xlf
@@ -1511,6 +1511,16 @@
         <source>Available widgets</source>
       </segment>
     </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.ariaLabel">
+      <segment>
+        <source>Gutter size between dashboard cells</source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.gutter.tooltip">
+      <segment>
+        <source>Gutter size between dashboard cells</source>
+      </segment>
+    </unit>
     <unit id="ngx.dashboard.widget.list.item.ariaLabel">
       <segment>
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>

--- a/projects/demo/src/locale/messages.xlf
+++ b/projects/demo/src/locale/messages.xlf
@@ -756,6 +756,16 @@
         <source>Realtime Gauge</source>
       </segment>
     </unit>
+    <unit id="demo.widgets.group.charts">
+      <segment>
+        <source>Charts</source>
+      </segment>
+    </unit>
+    <unit id="demo.widgets.group.sensors">
+      <segment>
+        <source>Sensors</source>
+      </segment>
+    </unit>
     <unit id="demo.widgets.realtimeGauge.description">
       <segment>
         <source>Gauge with real-time data updates</source>
@@ -1093,7 +1103,7 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment>
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1273,7 +1283,7 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment>
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">

--- a/projects/demo/src/locale/messages.xlf
+++ b/projects/demo/src/locale/messages.xlf
@@ -6,6 +6,11 @@
         <source>Dashboard</source>
       </segment>
     </unit>
+    <unit id="demo.navigation.menuAriaLabel">
+      <segment>
+        <source>Open navigation menu</source>
+      </segment>
+    </unit>
     <unit id="demo.navigation.radialGaugeDemo">
       <segment>
         <source>Radial Gauge Demo</source>
@@ -1103,7 +1108,7 @@
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.opacity">
       <segment>
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.arrow.dialog.background">
@@ -1283,7 +1288,7 @@
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.opacity">
       <segment>
-        <source> Opacity: <ph id="0" equiv="INTERPOLATION" disp="{{ formatOpacity(opacity()) }}"/>% </source>
+        <source> Opacity: <ph id="0" equiv="INTERPOLATION"/>% </source>
       </segment>
     </unit>
     <unit id="ngx.dashboard.widgets.label.dialog.background">
@@ -1509,6 +1514,26 @@
     <unit id="ngx.dashboard.widget.list.item.ariaLabel">
       <segment>
         <source><ph id="0" equiv="PH" disp="widget.name"/> widget: <ph id="1" equiv="PH_1" disp="widget.description"/></source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.ariaLabel">
+      <segment>
+        <source>Search widgets by name, description or type</source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.clear">
+      <segment>
+        <source>Clear widget search</source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.empty">
+      <segment>
+        <source> No matching widgets </source>
+      </segment>
+    </unit>
+    <unit id="ngx.dashboard.widget.list.search.placeholder">
+      <segment>
+        <source>Search widgets</source>
       </segment>
     </unit>
   </file>

--- a/projects/ngx-dashboard/src/lib/models/widget.ts
+++ b/projects/ngx-dashboard/src/lib/models/widget.ts
@@ -17,11 +17,12 @@ export interface WidgetMetadata {
    * Optional group heading for the widget list. Widgets sharing a group are
    * rendered together under that heading, in the order the groups were first
    * encountered during registration. Widgets without a group are listed last,
-   * without a heading — so omitting this field everywhere renders exactly the
-   * flat list as before.
+   * without a heading — so omitting this field everywhere renders a single
+   * unlabelled section, i.e. a flat list.
    *
-   * The value is displayed verbatim, so callers should pass an already
-   * localized string.
+   * The library never translates this value, so callers should pass an already
+   * localized string. Note that the default styling renders the heading
+   * upper-cased.
    */
   group?: string;
 }

--- a/projects/ngx-dashboard/src/lib/models/widget.ts
+++ b/projects/ngx-dashboard/src/lib/models/widget.ts
@@ -13,6 +13,17 @@ export interface WidgetMetadata {
   name: string; // to used in GUI
   description: string; // short description for tooltip / GUI
   svgIcon: string; // SVG markup as string
+  /**
+   * Optional group heading for the widget list. Widgets sharing a group are
+   * rendered together under that heading, in the order the groups were first
+   * encountered during registration. Widgets without a group are listed last,
+   * without a heading — so omitting this field everywhere renders exactly the
+   * flat list as before.
+   *
+   * The value is displayed verbatim, so callers should pass an already
+   * localized string.
+   */
+  group?: string;
 }
 
 export interface WidgetComponentClass<

--- a/projects/ngx-dashboard/src/lib/services/dashboard-bridge.service.ts
+++ b/projects/ngx-dashboard/src/lib/services/dashboard-bridge.service.ts
@@ -79,6 +79,25 @@ export class DashboardBridgeService {
   });
   
   /**
+   * Gutter size of the first available dashboard, or null when none is
+   * registered. Same "first available dashboard" convention as `startDrag`, so
+   * a widget list reads the gutter of the dashboard it drops onto.
+   */
+  readonly gutterSize = computed(() => {
+    const [first] = Array.from(this.dashboards().values());
+    return first ? first.store.gutterSize() : null;
+  });
+
+  /**
+   * Set the gutter size on the first available dashboard. No-op when none is
+   * registered. Counterpart to `gutterSize`.
+   */
+  setGutterSize(gutterSize: string): void {
+    const [first] = Array.from(this.dashboards().values());
+    first?.store.setGridConfig({ gutterSize });
+  }
+
+  /**
    * Start drag operation on the first available dashboard
    * (Widget lists need some dashboard to coordinate with during drag)
    */

--- a/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
@@ -16,7 +16,7 @@ function makeWidget(
     static metadata: WidgetMetadata = {
       widgetTypeid,
       name,
-      description: `${name} description`,
+      description: name + ' description',
       svgIcon: '<svg></svg>',
       group,
     };
@@ -41,66 +41,179 @@ describe('WidgetListComponent grouping', () => {
     component = fixture.componentInstance;
   });
 
-  it('renders a single unlabelled group when no widget declares one', () => {
-    dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
-    dashboardService.registerWidgetType(makeWidget('@test/b', 'B'));
+  describe('bucketing', () => {
+    it('renders a single unlabelled group when no widget declares one', () => {
+      dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B'));
 
-    const groups = component.widgetGroups();
+      const groups = component.widgetGroups();
 
-    expect(groups.length).toBe(1);
-    expect(groups[0].label).toBeUndefined();
-    expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
-      '@test/a',
-      '@test/b',
-    ]);
+      expect(groups.length).toBe(1);
+      expect(groups[0].label).toBeUndefined();
+      expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
+        '@test/a',
+        '@test/b',
+      ]);
+    });
+
+    it('buckets widgets sharing a group, keeping registration order', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+      dashboardService.registerWidgetType(
+        makeWidget('@test/c', 'C', 'Metrics')
+      );
+
+      const groups = component.widgetGroups();
+
+      expect(groups.map((g) => g.label)).toEqual(['Metrics', 'Layout']);
+      expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
+        '@test/a',
+        '@test/c',
+      ]);
+      expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/b']);
+    });
+
+    it('places ungrouped widgets in a trailing unlabelled group', () => {
+      dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
+      dashboardService.registerWidgetType(
+        makeWidget('@test/b', 'B', 'Metrics')
+      );
+
+      const groups = component.widgetGroups();
+
+      expect(groups.map((g) => g.label)).toEqual(['Metrics', undefined]);
+      expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/a']);
+    });
+
+    it('treats a blank group as no group', () => {
+      dashboardService.registerWidgetType(makeWidget('@test/a', 'A', '   '));
+
+      const groups = component.widgetGroups();
+
+      expect(groups.length).toBe(1);
+      expect(groups[0].label).toBeUndefined();
+    });
   });
 
-  it('buckets widgets sharing a group and keeps registration order within it', () => {
-    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', 'Metrics'));
-    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
-    dashboardService.registerWidgetType(makeWidget('@test/c', 'C', 'Metrics'));
+  describe('collapsing', () => {
+    it('starts every group expanded', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
 
-    const groups = component.widgetGroups();
+      expect(component.isGroupExpanded('Metrics')).toBe(true);
+      expect(component.isGroupExpanded(undefined)).toBe(true);
+    });
 
-    expect(groups.map((g) => g.label)).toEqual(['Metrics', 'Layout']);
-    expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
-      '@test/a',
-      '@test/c',
-    ]);
-    expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/b']);
+    it('toggles a group closed and open again', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+
+      component.toggleGroup('Metrics');
+      expect(component.isGroupExpanded('Metrics')).toBe(false);
+
+      component.toggleGroup('Metrics');
+      expect(component.isGroupExpanded('Metrics')).toBe(true);
+    });
+
+    it('toggles groups independently and ignores the unlabelled group', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+
+      component.toggleGroup('Metrics');
+      component.toggleGroup(undefined);
+
+      expect(component.isGroupExpanded('Metrics')).toBe(false);
+      expect(component.isGroupExpanded('Layout')).toBe(true);
+      expect(component.isGroupExpanded(undefined)).toBe(true);
+    });
+
+    it('hides the widgets of a collapsed group but keeps its heading', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+      fixture.detectChanges();
+
+      component.toggleGroup('Metrics');
+      fixture.detectChanges();
+
+      const headings =
+        fixture.nativeElement.querySelectorAll('.widget-group-label');
+      expect(headings.length).toBe(2);
+      expect(headings[0].getAttribute('aria-expanded')).toBe('false');
+      expect(headings[1].getAttribute('aria-expanded')).toBe('true');
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-list-item').length
+      ).toBe(1);
+    });
+
+    it('keeps widgets visible while the rail is icon-only', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      fixture.componentRef.setInput('collapsed', true);
+      fixture.detectChanges();
+
+      component.toggleGroup('Metrics');
+      fixture.detectChanges();
+
+      // There is no heading to toggle in the icon-only rail, so widgets stay
+      // visible and the heading is replaced by a divider.
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-list-item').length
+      ).toBe(1);
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-group-label').length
+      ).toBe(0);
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-group-divider').length
+      ).toBe(1);
+    });
   });
 
-  it('places ungrouped widgets in a trailing unlabelled group', () => {
-    dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
-    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Metrics'));
+  describe('rendering', () => {
+    it('renders a heading per labelled group', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+      fixture.detectChanges();
 
-    const groups = component.widgetGroups();
+      const labels = Array.from(
+        fixture.nativeElement.querySelectorAll('.widget-group-label-text')
+      ).map((el) => (el as HTMLElement).textContent?.trim());
 
-    expect(groups.map((g) => g.label)).toEqual(['Metrics', undefined]);
-    expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/a']);
-  });
+      expect(labels).toEqual(['Metrics', 'Layout']);
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-list-item').length
+      ).toBe(2);
+    });
 
-  it('treats a blank group as no group', () => {
-    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', '   '));
+    it('separates the trailing ungrouped widgets with a divider', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B'));
+      fixture.detectChanges();
 
-    const groups = component.widgetGroups();
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-group-divider').length
+      ).toBe(1);
+    });
 
-    expect(groups.length).toBe(1);
-    expect(groups[0].label).toBeUndefined();
-  });
+    it('omits the divider when every widget is ungrouped', () => {
+      dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
+      fixture.detectChanges();
 
-  it('renders a heading per labelled group', () => {
-    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', 'Metrics'));
-    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
-    fixture.detectChanges();
-
-    const labels = Array.from(
-      fixture.nativeElement.querySelectorAll('.widget-group-label-text')
-    ).map((el) => (el as HTMLElement).textContent?.trim());
-
-    expect(labels).toEqual(['Metrics', 'Layout']);
-    expect(
-      fixture.nativeElement.querySelectorAll('.widget-list-item').length
-    ).toBe(2);
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-group-divider').length
+      ).toBe(0);
+    });
   });
 });

--- a/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
@@ -25,6 +25,21 @@ function makeWidget(
   return TestWidgetComponent as WidgetComponentClass;
 }
 
+/**
+ * Widgets a user can actually see and drag. A collapsed expansion panel keeps
+ * its content in the DOM but marks the wrapper `inert`, so a plain
+ * `querySelectorAll` would also count hidden widgets.
+ */
+function visibleItems(
+  fixture: ComponentFixture<WidgetListComponent>
+): HTMLElement[] {
+  return (
+    Array.from(
+      fixture.nativeElement.querySelectorAll('.widget-list-item')
+    ) as HTMLElement[]
+  ).filter((el) => !el.closest('[inert]'));
+}
+
 describe('WidgetListComponent grouping', () => {
   let component: WidgetListComponent;
   let fixture: ComponentFixture<WidgetListComponent>;
@@ -148,9 +163,34 @@ describe('WidgetListComponent grouping', () => {
       expect(headings.length).toBe(2);
       expect(headings[0].getAttribute('aria-expanded')).toBe('false');
       expect(headings[1].getAttribute('aria-expanded')).toBe('true');
+      // The expansion panel keeps collapsed content in the DOM, but inert.
+      const visible = visibleItems(fixture);
+      expect(visible.length).toBe(1);
       expect(
-        fixture.nativeElement.querySelectorAll('.widget-list-item').length
-      ).toBe(1);
+        visible[0].closest('[role="list"]')?.getAttribute('aria-label')
+      ).toBe('Layout');
+    });
+
+    it('reflects a header click in the collapsed set', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      fixture.detectChanges();
+
+      const heading = fixture.nativeElement.querySelector(
+        '.widget-group-label'
+      ) as HTMLElement;
+      heading.click();
+      fixture.detectChanges();
+
+      expect(component.isGroupExpanded('Metrics')).toBe(false);
+      expect(visibleItems(fixture).length).toBe(0);
+
+      heading.click();
+      fixture.detectChanges();
+
+      expect(component.isGroupExpanded('Metrics')).toBe(true);
+      expect(visibleItems(fixture).length).toBe(1);
     });
 
     it('keeps widgets visible while the rail is icon-only', () => {
@@ -164,16 +204,28 @@ describe('WidgetListComponent grouping', () => {
       fixture.detectChanges();
 
       // There is no heading to toggle in the icon-only rail, so widgets stay
-      // visible and the heading is replaced by a divider.
-      expect(
-        fixture.nativeElement.querySelectorAll('.widget-list-item').length
-      ).toBe(1);
+      // visible even though the group is marked collapsed.
+      expect(component.isGroupExpanded('Metrics')).toBe(false);
+      expect(visibleItems(fixture).length).toBe(1);
       expect(
         fixture.nativeElement.querySelectorAll('.widget-group-label').length
       ).toBe(0);
-      expect(
-        fixture.nativeElement.querySelectorAll('.widget-group-divider').length
-      ).toBe(1);
+    });
+
+    it('restores the collapsed state when the rail expands again', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      fixture.detectChanges();
+
+      component.toggleGroup('Metrics');
+      fixture.componentRef.setInput('collapsed', true);
+      fixture.detectChanges();
+      fixture.componentRef.setInput('collapsed', false);
+      fixture.detectChanges();
+
+      expect(component.isGroupExpanded('Metrics')).toBe(false);
+      expect(visibleItems(fixture).length).toBe(0);
     });
   });
 
@@ -207,6 +259,21 @@ describe('WidgetListComponent grouping', () => {
       ).toBe(1);
     });
 
+    it('separates sections with dividers in the icon-only rail', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+      fixture.componentRef.setInput('collapsed', true);
+      fixture.detectChanges();
+
+      // No headings in the rail, so a divider is the only cue between sections
+      // — one between the two, none above the first.
+      expect(
+        fixture.nativeElement.querySelectorAll('.widget-group-divider').length
+      ).toBe(1);
+    });
+
     it('omits the divider when every widget is ungrouped', () => {
       dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
       fixture.detectChanges();
@@ -214,6 +281,64 @@ describe('WidgetListComponent grouping', () => {
       expect(
         fixture.nativeElement.querySelectorAll('.widget-group-divider').length
       ).toBe(0);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('renders one named list per section, each owning listitems', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      dashboardService.registerWidgetType(makeWidget('@test/b', 'B'));
+      fixture.detectChanges();
+
+      const lists = Array.from(
+        fixture.nativeElement.querySelectorAll('[role="list"]')
+      ) as HTMLElement[];
+
+      expect(lists.length).toBe(2);
+      expect(lists[0].getAttribute('aria-label')).toBe('Metrics');
+      expect(lists[1].hasAttribute('aria-label')).toBe(false);
+      for (const list of lists) {
+        expect(list.querySelectorAll('[role="listitem"]').length).toBe(1);
+      }
+    });
+
+    it('points the heading at the region it expands', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      fixture.detectChanges();
+
+      const heading = fixture.nativeElement.querySelector(
+        '.widget-group-label'
+      ) as HTMLElement;
+      const region = fixture.nativeElement.querySelector(
+        '[role="region"]'
+      ) as HTMLElement;
+
+      expect(region.id).toBeTruthy();
+      expect(heading.getAttribute('aria-controls')).toBe(region.id);
+      expect(region.getAttribute('aria-labelledby')).toBe(heading.id);
+      expect(region.querySelector('[role="list"]')).toBeTruthy();
+    });
+
+    it('makes a collapsed section inert', () => {
+      dashboardService.registerWidgetType(
+        makeWidget('@test/a', 'A', 'Metrics')
+      );
+      fixture.detectChanges();
+
+      component.toggleGroup('Metrics');
+      fixture.detectChanges();
+
+      const item = fixture.nativeElement.querySelector(
+        '.widget-list-item'
+      ) as HTMLElement;
+
+      // Still in the DOM, but not focusable, draggable or exposed to AT.
+      expect(item).toBeTruthy();
+      expect(item.closest('[inert]')).toBeTruthy();
     });
   });
 });

--- a/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-grouping.spec.ts
@@ -1,0 +1,106 @@
+// widget-list-grouping.spec.ts
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { WidgetListComponent } from '../widget-list.component';
+import { DashboardBridgeService } from '../../services/dashboard-bridge.service';
+import { DashboardService } from '../../services/dashboard.service';
+import { Widget, WidgetComponentClass, WidgetMetadata } from '../../models';
+
+function makeWidget(
+  widgetTypeid: string,
+  name: string,
+  group?: string
+): WidgetComponentClass {
+  @Component({ standalone: true, template: '' })
+  class TestWidgetComponent implements Widget {
+    static metadata: WidgetMetadata = {
+      widgetTypeid,
+      name,
+      description: `${name} description`,
+      svgIcon: '<svg></svg>',
+      group,
+    };
+  }
+
+  return TestWidgetComponent as WidgetComponentClass;
+}
+
+describe('WidgetListComponent grouping', () => {
+  let component: WidgetListComponent;
+  let fixture: ComponentFixture<WidgetListComponent>;
+  let dashboardService: DashboardService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WidgetListComponent],
+      providers: [DashboardBridgeService, DashboardService],
+    }).compileComponents();
+
+    dashboardService = TestBed.inject(DashboardService);
+    fixture = TestBed.createComponent(WidgetListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders a single unlabelled group when no widget declares one', () => {
+    dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
+    dashboardService.registerWidgetType(makeWidget('@test/b', 'B'));
+
+    const groups = component.widgetGroups();
+
+    expect(groups.length).toBe(1);
+    expect(groups[0].label).toBeUndefined();
+    expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
+      '@test/a',
+      '@test/b',
+    ]);
+  });
+
+  it('buckets widgets sharing a group and keeps registration order within it', () => {
+    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', 'Metrics'));
+    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+    dashboardService.registerWidgetType(makeWidget('@test/c', 'C', 'Metrics'));
+
+    const groups = component.widgetGroups();
+
+    expect(groups.map((g) => g.label)).toEqual(['Metrics', 'Layout']);
+    expect(groups[0].widgets.map((w) => w.widgetTypeid)).toEqual([
+      '@test/a',
+      '@test/c',
+    ]);
+    expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/b']);
+  });
+
+  it('places ungrouped widgets in a trailing unlabelled group', () => {
+    dashboardService.registerWidgetType(makeWidget('@test/a', 'A'));
+    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Metrics'));
+
+    const groups = component.widgetGroups();
+
+    expect(groups.map((g) => g.label)).toEqual(['Metrics', undefined]);
+    expect(groups[1].widgets.map((w) => w.widgetTypeid)).toEqual(['@test/a']);
+  });
+
+  it('treats a blank group as no group', () => {
+    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', '   '));
+
+    const groups = component.widgetGroups();
+
+    expect(groups.length).toBe(1);
+    expect(groups[0].label).toBeUndefined();
+  });
+
+  it('renders a heading per labelled group', () => {
+    dashboardService.registerWidgetType(makeWidget('@test/a', 'A', 'Metrics'));
+    dashboardService.registerWidgetType(makeWidget('@test/b', 'B', 'Layout'));
+    fixture.detectChanges();
+
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('.widget-group-label-text')
+    ).map((el) => (el as HTMLElement).textContent?.trim());
+
+    expect(labels).toEqual(['Metrics', 'Layout']);
+    expect(
+      fixture.nativeElement.querySelectorAll('.widget-list-item').length
+    ).toBe(2);
+  });
+});

--- a/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-gutter-slider.spec.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-gutter-slider.spec.ts
@@ -1,0 +1,144 @@
+// widget-list-gutter-slider.spec.ts
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { WidgetListComponent } from '../widget-list.component';
+import { formatGutterSize, parseGutterSize } from '../gutter-size';
+import { DashboardBridgeService } from '../../services/dashboard-bridge.service';
+import { DashboardService } from '../../services/dashboard.service';
+import { DashboardStore } from '../../store/dashboard-store';
+import { Widget, WidgetComponentClass, WidgetMetadata } from '../../models';
+
+function makeWidget(widgetTypeid: string): WidgetComponentClass {
+  @Component({ standalone: true, template: '' })
+  class TestWidgetComponent implements Widget {
+    static metadata: WidgetMetadata = {
+      widgetTypeid,
+      name: 'Test',
+      description: 'A widget',
+      svgIcon: '<svg></svg>',
+    };
+  }
+
+  return TestWidgetComponent as WidgetComponentClass;
+}
+
+describe('gutter size parsing', () => {
+  it('keeps the unit the dashboard authored', () => {
+    expect(parseGutterSize('0.5em')).toEqual({ value: 0.5, unit: 'em' });
+    expect(parseGutterSize('12px')).toEqual({ value: 12, unit: 'px' });
+    expect(parseGutterSize('1.25rem')).toEqual({ value: 1.25, unit: 'rem' });
+  });
+
+  it('falls back to the store default for units the slider cannot drive', () => {
+    for (const raw of ['2%', 'calc(1em + 2px)', '', 'auto', null]) {
+      expect(parseGutterSize(raw)).toEqual({ value: 0.5, unit: 'em' });
+    }
+  });
+
+  it('clamps to the top of the unit range', () => {
+    expect(parseGutterSize('99em')).toEqual({ value: 3, unit: 'em' });
+    expect(parseGutterSize('999px')).toEqual({ value: 48, unit: 'px' });
+  });
+
+  it('rounds away floating point noise from the slider steps', () => {
+    expect(formatGutterSize({ value: 0.1 + 0.05, unit: 'em' })).toBe('0.15em');
+    expect(formatGutterSize({ value: 8, unit: 'px' })).toBe('8px');
+  });
+});
+
+describe('WidgetListComponent gutter slider', () => {
+  let fixture: ComponentFixture<WidgetListComponent>;
+  let component: WidgetListComponent;
+  let bridge: DashboardBridgeService;
+  let store: InstanceType<typeof DashboardStore>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WidgetListComponent],
+      providers: [DashboardBridgeService, DashboardService, DashboardStore],
+    }).compileComponents();
+
+    TestBed.inject(DashboardService).registerWidgetType(makeWidget('@test/a'));
+    bridge = TestBed.inject(DashboardBridgeService);
+    store = TestBed.inject(DashboardStore);
+
+    fixture = TestBed.createComponent(WidgetListComponent);
+    component = fixture.componentInstance;
+  });
+
+  function dock(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('.gutter-dock');
+  }
+
+  /** Registers a dashboard so the bridge has something to drive. */
+  function registerDashboard(gutterSize = '0.5em'): void {
+    store.loadDashboard({
+      version: '1.1.0',
+      dashboardId: 'test-dashboard',
+      rows: 8,
+      columns: 16,
+      gutterSize,
+      cells: [],
+    });
+    bridge.registerDashboard(store);
+  }
+
+  it('is hidden unless enabled', () => {
+    registerDashboard();
+    fixture.componentRef.setInput('enableGutterSlider', false);
+    fixture.detectChanges();
+
+    expect(dock()).toBeNull();
+  });
+
+  it('is hidden until a dashboard registers: there is nothing to drive', () => {
+    fixture.componentRef.setInput('enableGutterSlider', true);
+    fixture.detectChanges();
+    expect(dock()).toBeNull();
+
+    registerDashboard();
+    fixture.detectChanges();
+    expect(dock()).not.toBeNull();
+  });
+
+  it('is hidden in the icon-only rail, which has no room for it', () => {
+    registerDashboard();
+    fixture.componentRef.setInput('enableGutterSlider', true);
+    fixture.componentRef.setInput('collapsed', true);
+    fixture.detectChanges();
+
+    expect(dock()).toBeNull();
+  });
+
+  it('takes its range and readout from the dashboard\'s own unit', () => {
+    registerDashboard('12px');
+    fixture.componentRef.setInput('enableGutterSlider', true);
+    fixture.detectChanges();
+
+    expect(component.gutterMax()).toBe(48);
+    expect(component.gutterStep()).toBe(1);
+    expect(component.gutterLabel()).toBe('12px');
+  });
+
+  it('writes slider input straight through to the dashboard', () => {
+    registerDashboard('0.5em');
+    fixture.componentRef.setInput('enableGutterSlider', true);
+    fixture.detectChanges();
+
+    component.onGutterInput(1.5);
+
+    expect(store.gutterSize()).toBe('1.5em');
+    expect(component.gutterLabel()).toBe('1.5em');
+  });
+
+  it('tracks a gutter changed elsewhere rather than holding its own copy', () => {
+    registerDashboard('0.5em');
+    fixture.componentRef.setInput('enableGutterSlider', true);
+    fixture.detectChanges();
+
+    store.setGridConfig({ gutterSize: '2rem' });
+
+    expect(component.gutter()).toEqual({ value: 2, unit: 'rem' });
+    expect(component.gutterMax()).toBe(3);
+  });
+});

--- a/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-search.spec.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/__tests__/widget-list-search.spec.ts
@@ -1,0 +1,199 @@
+// widget-list-search.spec.ts
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { WidgetListComponent } from '../widget-list.component';
+import { DashboardBridgeService } from '../../services/dashboard-bridge.service';
+import { DashboardService } from '../../services/dashboard.service';
+import { Widget, WidgetComponentClass, WidgetMetadata } from '../../models';
+
+function makeWidget(
+  widgetTypeid: string,
+  name: string,
+  description: string,
+  group?: string
+): WidgetComponentClass {
+  @Component({ standalone: true, template: '' })
+  class TestWidgetComponent implements Widget {
+    static metadata: WidgetMetadata = {
+      widgetTypeid,
+      name,
+      description,
+      svgIcon: '<svg></svg>',
+      group,
+    };
+  }
+
+  return TestWidgetComponent as WidgetComponentClass;
+}
+
+/** Widgets a user can actually see: collapsed panels keep theirs inert. */
+function visibleItems(
+  fixture: ComponentFixture<WidgetListComponent>
+): HTMLElement[] {
+  return (
+    Array.from(
+      fixture.nativeElement.querySelectorAll('.widget-list-item')
+    ) as HTMLElement[]
+  ).filter((el) => !el.closest('[inert]'));
+}
+
+describe('WidgetListComponent search', () => {
+  let component: WidgetListComponent;
+  let fixture: ComponentFixture<WidgetListComponent>;
+  let dashboardService: DashboardService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WidgetListComponent],
+      providers: [DashboardBridgeService, DashboardService],
+    }).compileComponents();
+
+    dashboardService = TestBed.inject(DashboardService);
+    fixture = TestBed.createComponent(WidgetListComponent);
+    component = fixture.componentInstance;
+
+    dashboardService.registerWidgetType(
+      makeWidget('@test/gauge', 'Radial Gauge', 'Shows a value on a dial')
+    );
+    dashboardService.registerWidgetType(
+      makeWidget('@test/label', 'Label', 'Static caption text', 'Basics')
+    );
+    dashboardService.registerWidgetType(
+      makeWidget('@test/arrow', 'Arrow', 'Points somewhere', 'Basics')
+    );
+  });
+
+  function typeSearch(term: string): void {
+    const input = fixture.nativeElement.querySelector(
+      '.widget-search input'
+    ) as HTMLInputElement;
+    input.value = term;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
+
+  it('lists every widget when the search box is empty', () => {
+    fixture.detectChanges();
+
+    expect(component.isFiltering()).toBe(false);
+    expect(visibleItems(fixture).length).toBe(3);
+  });
+
+  it('keeps only widgets whose name contains the term', () => {
+    component.searchTerm.set('gau');
+
+    expect(component.widgets().map((w) => w.widgetTypeid)).toEqual([
+      '@test/gauge',
+    ]);
+  });
+
+  it('matches the description', () => {
+    component.searchTerm.set('caption');
+
+    expect(component.widgets().map((w) => w.widgetTypeid)).toEqual([
+      '@test/label',
+    ]);
+  });
+
+  it('matches the widget type id', () => {
+    component.searchTerm.set('@test/arrow');
+
+    expect(component.widgets().map((w) => w.widgetTypeid)).toEqual([
+      '@test/arrow',
+    ]);
+  });
+
+  it('ignores case and surrounding whitespace', () => {
+    component.searchTerm.set('  RADIAL  ');
+
+    expect(component.widgets().map((w) => w.widgetTypeid)).toEqual([
+      '@test/gauge',
+    ]);
+    expect(component.isFiltering()).toBe(true);
+  });
+
+  it('drops groups left without a match', () => {
+    component.searchTerm.set('label');
+
+    expect(component.widgetGroups().map((g) => g.label)).toEqual(['Basics']);
+    expect(component.widgetGroups()[0].widgets.map((w) => w.name)).toEqual([
+      'Label',
+    ]);
+  });
+
+  it('renders matches from the input and an empty state when nothing matches', () => {
+    fixture.detectChanges();
+
+    typeSearch('arrow');
+    expect(visibleItems(fixture).length).toBe(1);
+    expect(
+      fixture.nativeElement.querySelector('.widget-search-empty')
+    ).toBeNull();
+
+    typeSearch('nothing here');
+    expect(visibleItems(fixture).length).toBe(0);
+    expect(
+      fixture.nativeElement.querySelector('.widget-search-empty')
+    ).not.toBeNull();
+  });
+
+  it('shows matches inside a group the user had collapsed, then restores it', () => {
+    fixture.detectChanges();
+
+    component.toggleGroup('Basics');
+    fixture.detectChanges();
+    expect(visibleItems(fixture).length).toBe(1); // the ungrouped gauge
+
+    typeSearch('label');
+    expect(component.isGroupExpanded('Basics')).toBe(true);
+    expect(visibleItems(fixture).length).toBe(1);
+    expect(visibleItems(fixture)[0].textContent).toContain('Label');
+
+    typeSearch('');
+    expect(component.isGroupExpanded('Basics')).toBe(false);
+  });
+
+  it('clears the filter from the clear button', () => {
+    fixture.detectChanges();
+    typeSearch('label');
+
+    const clear = fixture.nativeElement.querySelector(
+      '.widget-search-clear'
+    ) as HTMLButtonElement;
+    clear.click();
+    fixture.detectChanges();
+
+    expect(component.searchTerm()).toBe('');
+    expect(visibleItems(fixture).length).toBe(3);
+  });
+
+  it('drops the search box when disabled, and stops filtering with it', () => {
+    component.searchTerm.set('label');
+    fixture.componentRef.setInput('enableSearchBox', false);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.widget-search')).toBeNull();
+    expect(component.isFiltering()).toBe(false);
+    expect(visibleItems(fixture).length).toBe(3);
+  });
+
+  it('restores the term when the search box is enabled again', () => {
+    component.searchTerm.set('label');
+    fixture.componentRef.setInput('enableSearchBox', false);
+    fixture.detectChanges();
+
+    fixture.componentRef.setInput('enableSearchBox', true);
+    fixture.detectChanges();
+
+    expect(visibleItems(fixture).length).toBe(1);
+  });
+
+  it('hides the search box in the icon-only rail but keeps filtering', () => {
+    component.searchTerm.set('label');
+    fixture.componentRef.setInput('collapsed', true);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.widget-search')).toBeNull();
+    expect(visibleItems(fixture).length).toBe(1);
+  });
+});

--- a/projects/ngx-dashboard/src/lib/widget-list/gutter-size.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/gutter-size.ts
@@ -1,0 +1,48 @@
+// gutter-size.ts
+//
+// Helpers for driving a dashboard's CSS gutter length from a numeric slider.
+
+/**
+ * Units the gutter slider can drive, with the range that makes sense for each.
+ * A gutter is a small inter-cell gap, so the ranges stay deliberately tight —
+ * wide enough to be useful, narrow enough that the slider keeps usable
+ * resolution.
+ */
+export const GUTTER_UNITS = {
+  px: { max: 48, step: 1 },
+  em: { max: 3, step: 0.05 },
+  rem: { max: 3, step: 0.05 },
+} as const;
+
+export type GutterUnit = keyof typeof GUTTER_UNITS;
+
+export interface GutterSize {
+  value: number;
+  unit: GutterUnit;
+}
+
+/** Matches `DashboardStore`'s own default, so an unparseable value lands there. */
+const DEFAULT_GUTTER: GutterSize = { value: 0.5, unit: 'em' };
+
+/**
+ * Splits a CSS gutter length into the number the slider drives and the unit it
+ * keeps. Only the units the slider can render are recognised; anything else
+ * (`calc()`, `%`, `vw`, an empty string) falls back to the store default rather
+ * than being silently reinterpreted in the wrong unit.
+ */
+export function parseGutterSize(raw: string | null | undefined): GutterSize {
+  const match = /^\s*(\d*\.?\d+)\s*(px|em|rem)?\s*$/i.exec(raw ?? '');
+  if (!match) return { ...DEFAULT_GUTTER };
+
+  const unit = (match[2]?.toLowerCase() as GutterUnit | undefined) ?? 'em';
+  return { value: Math.min(Number(match[1]), GUTTER_UNITS[unit].max), unit };
+}
+
+/**
+ * Renders a gutter size back to CSS. Rounded to two decimals because the
+ * fractional slider steps otherwise surface floating point noise
+ * (`0.15000000000000002em`) in the exported dashboard.
+ */
+export function formatGutterSize({ value, unit }: GutterSize): string {
+  return `${Number(value.toFixed(2))}${unit}`;
+}

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
@@ -5,6 +5,49 @@
   i18n-aria-label="@@ngx.dashboard.widget.list.available"
   aria-label="Available widgets"
 >
+  <!-- No room for a text field in the icon-only rail; the filter stays applied
+       while collapsed so expanding restores what the user searched for. -->
+  @if (showSearchBox()) {
+  <!-- Filled appearance, like every other field in a Material app; an outlined
+       one would read as a foreign control inside the surface. -->
+  <mat-form-field class="widget-search" subscriptSizing="dynamic">
+    <mat-icon matPrefix class="widget-search-icon">search</mat-icon>
+    <!-- A placeholder, not a `mat-label`: Material hides the filled field's
+         label from density -2 down, and hosts commonly run the form fields
+         denser than the default. -->
+    <input
+      matInput
+      type="text"
+      autocomplete="off"
+      [value]="searchTerm()"
+      (input)="onSearchInput($any($event.target).value)"
+      i18n-placeholder="@@ngx.dashboard.widget.list.search.placeholder"
+      placeholder="Search widgets"
+      i18n-aria-label="@@ngx.dashboard.widget.list.search.ariaLabel"
+      aria-label="Search widgets by name, description or type"
+    />
+    @if (isFiltering()) {
+    <button
+      matSuffix
+      mat-icon-button
+      type="button"
+      class="widget-search-clear"
+      (click)="clearSearch()"
+      i18n-aria-label="@@ngx.dashboard.widget.list.search.clear"
+      aria-label="Clear widget search"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+    }
+  </mat-form-field>
+  }
+
+  @if (isFiltering() && widgetGroups().length === 0) {
+  <p class="widget-search-empty" i18n="@@ngx.dashboard.widget.list.search.empty">
+    No matching widgets
+  </p>
+  }
+
   @if (collapsed()) {
   <!-- Icon-only rail: no room for headings, so the sections degrade to
        dividers and cannot be collapsed. -->

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
@@ -91,6 +91,40 @@
     } }
   </mat-accordion>
   }
+
+  <!-- Docked to the list's bottom-left corner and sticky, so it stays put
+       however long the list runs. Writes straight through to the dashboard:
+       the grid reflows under the thumb, which is the whole point of a slider
+       here rather than a number in a dialog. -->
+  @if (showGutterSlider()) {
+  <div class="gutter-dock">
+    <div class="gutter-control">
+      <mat-icon
+        class="gutter-control-icon"
+        aria-hidden="true"
+        i18n-matTooltip="@@ngx.dashboard.widget.list.gutter.tooltip"
+        matTooltip="Gutter size between dashboard cells"
+        matTooltipPosition="above"
+        >grid_view</mat-icon
+      >
+      <mat-slider
+        class="gutter-slider"
+        [min]="0"
+        [max]="gutterMax()"
+        [step]="gutterStep()"
+      >
+        <input
+          matSliderThumb
+          [value]="gutter().value"
+          (input)="onGutterInput($any($event.target).valueAsNumber)"
+          i18n-aria-label="@@ngx.dashboard.widget.list.gutter.ariaLabel"
+          aria-label="Gutter size between dashboard cells"
+        />
+      </mat-slider>
+      <span class="gutter-value">{{ gutterLabel() }}</span>
+    </div>
+  </div>
+  }
 </div>
 
 <!-- One list per section, so every rendered list owns listitem children even

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
@@ -5,26 +5,38 @@
   i18n-aria-label="@@ngx.dashboard.widget.list.available"
   aria-label="Available widgets"
 >
-  @for (widget of widgets(); track widget.widgetTypeid) {
-  <div
-    class="widget-list-item"
-    [class.active]="activeWidget() === widget.widgetTypeid"
-    draggable="true"
-    (dragstart)="onDragStart($event, widget)"
-    (dragend)="onDragEnd()"
-    role="listitem"
-    [attr.aria-grabbed]="activeWidget() === widget.widgetTypeid"
-    [attr.aria-label]="getWidgetAriaLabel(widget)"
-    [matTooltip]="widget.description"
-    [matTooltipDisabled]="!collapsed()"
-    matTooltipPosition="right"
-    tabindex="0"
-  >
-    <div class="icon" [innerHTML]="widget.safeSvgIcon" aria-hidden="true"></div>
-    <div class="content">
-      <strong>{{ widget.name }}</strong>
-      <small>{{ widget.description }}</small>
+  @for (group of widgetGroups(); track group.label ?? '') {
+  <div class="widget-group" role="group" [attr.aria-label]="group.label">
+    @if (group.label) {
+    <div class="widget-group-label" [class.collapsed]="collapsed()">
+      <span class="widget-group-label-text">{{ group.label }}</span>
     </div>
+    } @for (widget of group.widgets; track widget.widgetTypeid) {
+    <div
+      class="widget-list-item"
+      [class.active]="activeWidget() === widget.widgetTypeid"
+      draggable="true"
+      (dragstart)="onDragStart($event, widget)"
+      (dragend)="onDragEnd()"
+      role="listitem"
+      [attr.aria-grabbed]="activeWidget() === widget.widgetTypeid"
+      [attr.aria-label]="getWidgetAriaLabel(widget)"
+      [matTooltip]="widget.description"
+      [matTooltipDisabled]="!collapsed()"
+      matTooltipPosition="right"
+      tabindex="0"
+    >
+      <div
+        class="icon"
+        [innerHTML]="widget.safeSvgIcon"
+        aria-hidden="true"
+      ></div>
+      <div class="content">
+        <strong>{{ widget.name }}</strong>
+        <small>{{ widget.description }}</small>
+      </div>
+    </div>
+    }
   </div>
   }
 </div>

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
@@ -1,41 +1,60 @@
 <!-- widget-list.component.html -->
 <div
   class="widget-list"
-  role="list"
+  role="group"
   i18n-aria-label="@@ngx.dashboard.widget.list.available"
   aria-label="Available widgets"
 >
-  @for (group of widgetGroups(); track group.label ?? '') {
-  <div class="widget-group" role="group" [attr.aria-label]="group.label">
-    @if (group.label; as groupLabel) { @if (collapsed()) {
-    <!-- Icon-only rail: no room for the heading, so it degrades to a divider
-         and the group cannot be toggled. -->
-    <div class="widget-group-divider" aria-hidden="true"></div>
-    } @else {
-    <button
-      type="button"
-      class="widget-group-label"
-      [attr.aria-expanded]="isGroupExpanded(groupLabel)"
-      (click)="toggleGroup(groupLabel)"
+  @if (collapsed()) {
+  <!-- Icon-only rail: no room for headings, so the sections degrade to
+       dividers and cannot be collapsed. -->
+  @for (group of widgetGroups(); track group.label ?? '') { @if ($index > 0) {
+  <mat-divider class="widget-group-divider" />
+  }
+  <ng-container
+    [ngTemplateOutlet]="widgetSection"
+    [ngTemplateOutletContext]="{ $implicit: group }"
+  />
+  } } @else {
+  <mat-accordion class="widget-group-accordion" multi displayMode="flat">
+    @for (group of widgetGroups(); track group.label ?? '') { @if (group.label;
+    as groupLabel) {
+    <mat-expansion-panel
+      class="widget-group-panel"
+      [expanded]="isGroupExpanded(groupLabel)"
+      (opened)="setGroupExpanded(groupLabel, true)"
+      (closed)="setGroupExpanded(groupLabel, false)"
     >
-      <svg
-        class="widget-group-chevron"
-        [class.collapsed]="!isGroupExpanded(groupLabel)"
-        viewBox="0 -960 960 960"
-        aria-hidden="true"
-      >
-        <path fill="currentColor" d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z" />
-      </svg>
-      <span class="widget-group-label-text">{{ groupLabel }}</span>
-    </button>
-    } } @else if ($index > 0) {
+      <mat-expansion-panel-header class="widget-group-label">
+        <mat-panel-title class="widget-group-title">
+          <span class="widget-group-label-text">{{ groupLabel }}</span>
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+      <ng-container
+        [ngTemplateOutlet]="widgetSection"
+        [ngTemplateOutletContext]="{ $implicit: group }"
+      />
+    </mat-expansion-panel>
+    } @else {
     <!-- Ungrouped widgets trail the labelled groups; without this they read as
          part of the group above. -->
-    <div class="widget-group-divider" aria-hidden="true"></div>
+    @if ($index > 0) {
+    <mat-divider class="widget-group-divider" />
     }
+    <ng-container
+      [ngTemplateOutlet]="widgetSection"
+      [ngTemplateOutletContext]="{ $implicit: group }"
+    />
+    } }
+  </mat-accordion>
+  }
+</div>
 
-    @if (collapsed() || isGroupExpanded(group.label)) { @for (widget of
-    group.widgets; track widget.widgetTypeid) {
+<!-- One list per section, so every rendered list owns listitem children even
+     when other sections are collapsed. -->
+<ng-template #widgetSection let-group>
+  <div class="widget-group" role="list" [attr.aria-label]="group.label">
+    @for (widget of group.widgets; track widget.widgetTypeid) {
     <div
       class="widget-list-item"
       [class.active]="activeWidget() === widget.widgetTypeid"
@@ -50,17 +69,12 @@
       matTooltipPosition="right"
       tabindex="0"
     >
-      <div
-        class="icon"
-        [innerHTML]="widget.safeSvgIcon"
-        aria-hidden="true"
-      ></div>
+      <div class="icon" [innerHTML]="widget.safeSvgIcon" aria-hidden="true"></div>
       <div class="content">
         <strong>{{ widget.name }}</strong>
         <small>{{ widget.description }}</small>
       </div>
     </div>
-    } }
+    }
   </div>
-  }
-</div>
+</ng-template>

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.html
@@ -7,11 +7,35 @@
 >
   @for (group of widgetGroups(); track group.label ?? '') {
   <div class="widget-group" role="group" [attr.aria-label]="group.label">
-    @if (group.label) {
-    <div class="widget-group-label" [class.collapsed]="collapsed()">
-      <span class="widget-group-label-text">{{ group.label }}</span>
-    </div>
-    } @for (widget of group.widgets; track widget.widgetTypeid) {
+    @if (group.label; as groupLabel) { @if (collapsed()) {
+    <!-- Icon-only rail: no room for the heading, so it degrades to a divider
+         and the group cannot be toggled. -->
+    <div class="widget-group-divider" aria-hidden="true"></div>
+    } @else {
+    <button
+      type="button"
+      class="widget-group-label"
+      [attr.aria-expanded]="isGroupExpanded(groupLabel)"
+      (click)="toggleGroup(groupLabel)"
+    >
+      <svg
+        class="widget-group-chevron"
+        [class.collapsed]="!isGroupExpanded(groupLabel)"
+        viewBox="0 -960 960 960"
+        aria-hidden="true"
+      >
+        <path fill="currentColor" d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z" />
+      </svg>
+      <span class="widget-group-label-text">{{ groupLabel }}</span>
+    </button>
+    } } @else if ($index > 0) {
+    <!-- Ungrouped widgets trail the labelled groups; without this they read as
+         part of the group above. -->
+    <div class="widget-group-divider" aria-hidden="true"></div>
+    }
+
+    @if (collapsed() || isGroupExpanded(group.label)) { @for (widget of
+    group.widgets; track widget.widgetTypeid) {
     <div
       class="widget-list-item"
       [class.active]="activeWidget() === widget.widgetTypeid"
@@ -36,7 +60,7 @@
         <small>{{ widget.description }}</small>
       </div>
     </div>
-    }
+    } }
   </div>
   }
 </div>

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -19,6 +19,45 @@
   }
 }
 
+// Groups inherit the list's own column layout and gap, so a grouped list has
+// the same rhythm as a flat one.
+.widget-group {
+  display: flex;
+  flex-direction: column;
+  gap: inherit;
+}
+
+.widget-group-label {
+  display: flex;
+  align-items: center;
+  color: var(--mat-sys-on-surface-variant, #5f5f5f);
+  font-size: clamp(0.6875rem, 1.8vw, 0.75rem);
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+
+  .widget-group-label-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // Collapsed (icon-only) rail: there is no room for the text, so the heading
+  // degrades to a divider that still separates the groups visually.
+  &.collapsed {
+    justify-content: center;
+    border-top: 1px solid var(--mat-sys-outline-variant, #c7c7c7);
+
+    .widget-group-label-text {
+      display: none;
+    }
+  }
+}
+
+.widget-group:first-child .widget-group-label.collapsed {
+  border-top: none;
+}
+
 .widget-list-item {
   display: flex;
   align-items: start;

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -19,73 +19,85 @@
   }
 }
 
-// Groups inherit the list's own column layout and gap, so a grouped list has
-// the same rhythm as a flat one.
+// Each section is its own list, inheriting the outer column layout and gap so a
+// grouped list keeps the same rhythm as a flat one.
 .widget-group {
   display: flex;
   flex-direction: column;
   gap: inherit;
 }
 
-// Clickable heading that collapses/expands the group.
-.widget-group-label {
+// The accordion is a layout-neutral wrapper: it keeps the list's own column
+// rhythm so panels line up with ungrouped widgets.
+.widget-group-accordion {
   display: flex;
-  align-items: center;
-  gap: var(--mat-sys-spacing-1, 4px);
-  width: 100%;
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--mat-sys-on-surface-variant, #5f5f5f);
-  font-family: inherit;
-  font-size: clamp(0.6875rem, 1.8vw, 0.75rem);
-  font-weight: 500;
-  letter-spacing: 0.5px;
-  text-align: left;
+  flex-direction: column;
+  gap: inherit;
+}
+
+// Strip the panel's card chrome — in a narrow sidebar it should read as a
+// section heading, not as an elevated surface.
+.widget-group-panel {
+  --mat-expansion-container-background-color: transparent;
+  --mat-expansion-container-shape: 0;
+  --mat-expansion-container-elevation-shadow: none;
+  --mat-expansion-header-collapsed-state-height: 32px;
+  --mat-expansion-header-expanded-state-height: 32px;
+  --mat-expansion-header-text-color: var(--mat-sys-on-surface-variant, #5f5f5f);
+  --mat-expansion-header-text-size: clamp(0.6875rem, 1.8vw, 0.75rem);
+  --mat-expansion-header-text-weight: 500;
+  --mat-expansion-header-text-tracking: 0.5px;
+  --mat-expansion-header-indicator-color: var(
+    --mat-sys-on-surface-variant,
+    #5f5f5f
+  );
+
+  // The sidebar already provides the outer padding, so the heading and the
+  // widgets below it stay aligned on the same edge.
+  ::ng-deep .mat-expansion-panel-body {
+    padding: 0;
+  }
+
+  // Material lays the chevron out as an inline `::after` whose rotated box
+  // overflows its own bounds, so the panel's `overflow: hidden` clips it. A
+  // centred box big enough for the rotation keeps it whole.
+  ::ng-deep .mat-expansion-indicator {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+mat-expansion-panel-header.widget-group-label {
+  // Only the trailing edge is padded: the label stays flush with the widgets
+  // below, while the chevron keeps clear of the panel edge.
+  padding: 0 var(--mat-sys-spacing-1, 4px) 0 0;
+}
+
+mat-panel-title.widget-group-title {
+  min-width: 0; // Allow the label to truncate instead of overflowing
+  margin-right: var(--mat-sys-spacing-2, 8px);
+  overflow: hidden;
+}
+
+.widget-group-label-text {
+  min-width: 0; // Allow the label to truncate instead of overflowing
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   text-transform: uppercase;
-  cursor: pointer;
-
-  &:hover {
-    color: var(--mat-sys-on-surface, #1c1c1c);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--mat-sys-primary, #1976d2);
-    outline-offset: 2px;
-  }
-
-  .widget-group-label-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 }
 
-.widget-group-chevron {
-  width: 1rem;
-  height: 1rem;
-  flex-shrink: 0;
-  transition: transform var(--mat-sys-motion-duration-short2, 150ms)
-    var(--mat-sys-motion-easing-standard, ease-in-out);
-
-  &.collapsed {
-    transform: rotate(-90deg);
-  }
-}
-
-// Separates groups where no heading does it: before the trailing ungrouped
-// widgets, and between groups in the icon-only rail. Deliberately stronger than
-// a hairline `outline-variant` rule — it is the only cue that the widgets below
-// are not part of the group above.
-.widget-group-divider {
-  height: 2px;
+// Separates sections where no heading does it: before the trailing ungrouped
+// widgets, and between sections in the icon-only rail. Left at Material's
+// default hairline `outline-variant` rule so it reads as a soft separator
+// rather than a border; only the surrounding space is ours.
+mat-divider.widget-group-divider {
   margin: var(--mat-sys-spacing-2, 8px) 0;
-  border-radius: 1px;
-  background-color: var(--mat-sys-outline, #757575);
-}
-
-.widget-group:first-child .widget-group-divider {
-  display: none;
 }
 
 .widget-list-item {

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -2,13 +2,19 @@
 :host {
   background-color: var(--mat-sys-surface-container, #f5f5f5);
   container-type: inline-size;
+
+  // Column layout so the list can claim the host's full height; without it the
+  // docked slider has no bottom to sit against on a short list.
+  display: flex;
+  flex-direction: column;
 }
 
 .widget-list {
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: var(--mat-sys-spacing-2, 8px);
-  
+
   // Responsive spacing based on container width
   @container (max-width: 200px) {
     gap: var(--mat-sys-spacing-1, 4px);
@@ -37,6 +43,72 @@
     opacity: 0.7;
     margin-inline: var(--mat-sys-spacing-2, 8px) var(--mat-sys-spacing-1, 4px);
   }
+}
+
+// Holds the control in the list's bottom-left corner. `margin-top: auto` drops
+// it there on a short list; `position: sticky` keeps it there on a long one, so
+// it never scrolls out of reach.
+//
+// Full width rather than shrink-to-fit, and painted in the list's own surface:
+// the control alone would let widget cards scroll through the space beside it.
+// The width is the list's content box, which is also where the cards are, so
+// nothing shows past either edge. `bottom: 0` rather than an inset keeps cards
+// from peeking through underneath it too.
+.gutter-dock {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  margin-top: auto;
+
+  display: flex;
+  justify-content: flex-start;
+
+  background-color: var(--mat-sys-surface-container, #f5f5f5);
+  // Vertical padding is the clearance: it keeps the card scrolling underneath
+  // from touching the control, and keeps the last card clear of it at rest.
+  padding-block: var(--mat-sys-spacing-2, 8px);
+}
+
+// Elevated on the container-high surface so it separates from both the list
+// background and the widget cards sliding under the dock.
+.gutter-control {
+  display: flex;
+  align-items: center;
+  gap: var(--mat-sys-spacing-2, 8px);
+  padding-inline: var(--mat-sys-spacing-3, 12px);
+
+  background-color: var(--mat-sys-surface-container-high, #ececec);
+  border-radius: var(--mat-sys-corner-full, 999px);
+  box-shadow: var(--mat-sys-elevation-level2, 0 2px 4px rgba(0, 0, 0, 0.1));
+
+  .gutter-control-icon {
+    flex-shrink: 0;
+    color: var(--mat-sys-on-surface-variant, #5f5f5f);
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+// Material sizes a slider to fill its container, which here would be the pill's
+// intrinsic width — a circular argument. A fixed track keeps the pill compact
+// and leaves the readout room.
+.gutter-slider {
+  flex: 0 0 auto;
+  width: 104px;
+  min-width: 0;
+  --mat-slider-value-indicator-opacity: 0;
+}
+
+// Fixed width in digit units, so dragging the thumb doesn't jitter the pill as
+// the readout gains and loses characters.
+.gutter-value {
+  flex: 0 0 auto;
+  min-width: 5ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(0.6875rem, 1.8vw, 0.75rem);
+  color: var(--mat-sys-on-surface-variant, #5f5f5f);
 }
 
 .widget-search-empty {

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -73,13 +73,19 @@
   }
 }
 
-// Stand-in for the heading when the rail is collapsed to icons only.
+// Separates groups where no heading does it: before the trailing ungrouped
+// widgets, and between groups in the icon-only rail. Deliberately stronger than
+// a hairline `outline-variant` rule — it is the only cue that the widgets below
+// are not part of the group above.
 .widget-group-divider {
-  border-top: 1px solid var(--mat-sys-outline-variant, #c7c7c7);
+  height: 2px;
+  margin: var(--mat-sys-spacing-2, 8px) 0;
+  border-radius: 1px;
+  background-color: var(--mat-sys-outline, #757575);
 }
 
 .widget-group:first-child .widget-group-divider {
-  border-top: none;
+  display: none;
 }
 
 .widget-list-item {

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -27,34 +27,58 @@
   gap: inherit;
 }
 
+// Clickable heading that collapses/expands the group.
 .widget-group-label {
   display: flex;
   align-items: center;
+  gap: var(--mat-sys-spacing-1, 4px);
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--mat-sys-on-surface-variant, #5f5f5f);
+  font-family: inherit;
   font-size: clamp(0.6875rem, 1.8vw, 0.75rem);
   font-weight: 500;
   letter-spacing: 0.5px;
+  text-align: left;
   text-transform: uppercase;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--mat-sys-on-surface, #1c1c1c);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--mat-sys-primary, #1976d2);
+    outline-offset: 2px;
+  }
 
   .widget-group-label-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+}
 
-  // Collapsed (icon-only) rail: there is no room for the text, so the heading
-  // degrades to a divider that still separates the groups visually.
+.widget-group-chevron {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  transition: transform var(--mat-sys-motion-duration-short2, 150ms)
+    var(--mat-sys-motion-easing-standard, ease-in-out);
+
   &.collapsed {
-    justify-content: center;
-    border-top: 1px solid var(--mat-sys-outline-variant, #c7c7c7);
-
-    .widget-group-label-text {
-      display: none;
-    }
+    transform: rotate(-90deg);
   }
 }
 
-.widget-group:first-child .widget-group-label.collapsed {
+// Stand-in for the heading when the rail is collapsed to icons only.
+.widget-group-divider {
+  border-top: 1px solid var(--mat-sys-outline-variant, #c7c7c7);
+}
+
+.widget-group:first-child .widget-group-divider {
   border-top: none;
 }
 

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.scss
@@ -19,6 +19,33 @@
   }
 }
 
+// Full-width filter field above the sections. `subscriptSizing="dynamic"` keeps
+// it from reserving hint space, so it sits tight against the first group.
+.widget-search {
+  width: 100%;
+
+  // The list sits on `surface-container`, so the field's default
+  // `surface-container-highest` fill is the one step of contrast it needs —
+  // any darker and it competes with the widget cards below.
+  --mdc-filled-text-field-container-color: var(
+    --mat-sys-surface-container-high,
+    #ececec
+  );
+
+  .widget-search-icon {
+    color: var(--mat-sys-on-surface-variant, #5f5f5f);
+    opacity: 0.7;
+    margin-inline: var(--mat-sys-spacing-2, 8px) var(--mat-sys-spacing-1, 4px);
+  }
+}
+
+.widget-search-empty {
+  margin: var(--mat-sys-spacing-2, 8px) 0;
+  color: var(--mat-sys-on-surface-variant, #5f5f5f);
+  font-size: clamp(0.75rem, 2vw, 0.875rem);
+  text-align: center;
+}
+
 // Each section is its own list, inheriting the outer column layout and gap so a
 // grouped list keeps the same rhythm as a flat one.
 .widget-group {
@@ -98,6 +125,13 @@ mat-panel-title.widget-group-title {
 // rather than a border; only the surrounding space is ours.
 mat-divider.widget-group-divider {
   margin: var(--mat-sys-spacing-2, 8px) 0;
+  // Material's default rule is `outline-variant` at full strength, which cuts
+  // the narrow sidebar in two. Half strength still separates the sections.
+  border-top-color: color-mix(
+    in srgb,
+    var(--mat-sys-outline-variant, #c7c7c7) 50%,
+    transparent
+  );
 }
 
 .widget-list-item {

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
@@ -45,6 +45,13 @@ export class WidgetListComponent {
   // Input to track collapsed state for tooltip display
   collapsed = input<boolean>(false);
 
+  /**
+   * Labels of the groups the user has collapsed. Groups start expanded, and the
+   * state is per component instance (not persisted) — the list is a transient
+   * editing surface.
+   */
+  readonly #collapsedGroups = signal<ReadonlySet<string>>(new Set<string>());
+
   activeWidget = signal<string | null>(null);
 
   // Get grid cell dimensions from bridge service (uses first available dashboard)
@@ -90,6 +97,27 @@ export class WidgetListComponent {
       ? [...labelled, { widgets: ungrouped }]
       : labelled;
   });
+
+  /**
+   * Whether a group's widgets are shown. Ungrouped widgets have no heading to
+   * toggle, so they are always shown.
+   */
+  isGroupExpanded(label?: string): boolean {
+    return !label || !this.#collapsedGroups().has(label);
+  }
+
+  /** Toggles a group open/closed. No-op for the unlabelled group. */
+  toggleGroup(label?: string): void {
+    if (!label) return;
+
+    this.#collapsedGroups.update((collapsed) => {
+      const next = new Set(collapsed);
+      if (!next.delete(label)) {
+        next.add(label);
+      }
+      return next;
+    });
+  }
 
   onDragStart(event: DragEvent, widget: WidgetDisplayItem) {
     if (!event.dataTransfer) return;

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
@@ -8,11 +8,14 @@ import {
   input,
   ChangeDetectionStrategy,
 } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { DragData, WidgetMetadata } from '../models';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { DashboardService } from '../services/dashboard.service';
 import { DashboardBridgeService } from '../services/dashboard-bridge.service';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatDividerModule } from '@angular/material/divider';
 
 interface WidgetDisplayItem extends WidgetMetadata {
   safeSvgIcon?: SafeHtml;
@@ -31,7 +34,12 @@ interface WidgetListGroup {
 @Component({
   selector: 'ngx-dashboard-widget-list',
   standalone: true,
-  imports: [MatTooltipModule],
+  imports: [
+    NgTemplateOutlet,
+    MatTooltipModule,
+    MatExpansionModule,
+    MatDividerModule,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './widget-list.component.html',
   styleUrl: './widget-list.component.scss',
@@ -69,7 +77,7 @@ export class WidgetListComponent {
    * they were first seen in the registration order, widgets keep their
    * registration order within a group, and ungrouped widgets trail the labelled
    * groups in a single unlabelled section. With no widget declaring a group the
-   * result is one unlabelled section, i.e. the previous flat rendering.
+   * result is one unlabelled section, i.e. a flat list with no heading.
    */
   widgetGroups = computed<WidgetListGroup[]>(() => {
     const labelled: WidgetListGroup[] = [];
@@ -109,10 +117,23 @@ export class WidgetListComponent {
   /** Toggles a group open/closed. No-op for the unlabelled group. */
   toggleGroup(label?: string): void {
     if (!label) return;
+    this.setGroupExpanded(label, !this.isGroupExpanded(label));
+  }
+
+  /**
+   * Records a group's expanded state. Idempotent, so it is safe to drive from
+   * the expansion panel's `opened`/`closed` outputs.
+   */
+  setGroupExpanded(label: string | undefined, expanded: boolean): void {
+    if (!label) return;
 
     this.#collapsedGroups.update((collapsed) => {
+      if (collapsed.has(label) === !expanded) return collapsed;
+
       const next = new Set(collapsed);
-      if (!next.delete(label)) {
+      if (expanded) {
+        next.delete(label);
+      } else {
         next.add(label);
       }
       return next;

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
@@ -18,6 +18,16 @@ interface WidgetDisplayItem extends WidgetMetadata {
   safeSvgIcon?: SafeHtml;
 }
 
+/**
+ * A rendered section of the widget list. `label` is undefined for the trailing
+ * section holding widgets that declare no `WidgetMetadata.group`; that section
+ * is rendered without a heading.
+ */
+interface WidgetListGroup {
+  label?: string;
+  widgets: WidgetDisplayItem[];
+}
+
 @Component({
   selector: 'ngx-dashboard-widget-list',
   standalone: true,
@@ -46,6 +56,40 @@ export class WidgetListComponent {
       safeSvgIcon: this.#sanitizer.bypassSecurityTrustHtml(w.metadata.svgIcon),
     }))
   );
+
+  /**
+   * Widgets bucketed by `WidgetMetadata.group`. Groups keep the order in which
+   * they were first seen in the registration order, widgets keep their
+   * registration order within a group, and ungrouped widgets trail the labelled
+   * groups in a single unlabelled section. With no widget declaring a group the
+   * result is one unlabelled section, i.e. the previous flat rendering.
+   */
+  widgetGroups = computed<WidgetListGroup[]>(() => {
+    const labelled: WidgetListGroup[] = [];
+    const byLabel = new Map<string, WidgetListGroup>();
+    const ungrouped: WidgetDisplayItem[] = [];
+
+    for (const widget of this.widgets()) {
+      const label = widget.group?.trim();
+
+      if (!label) {
+        ungrouped.push(widget);
+        continue;
+      }
+
+      let group = byLabel.get(label);
+      if (!group) {
+        group = { label, widgets: [] };
+        byLabel.set(label, group);
+        labelled.push(group);
+      }
+      group.widgets.push(widget);
+    }
+
+    return ungrouped.length > 0
+      ? [...labelled, { widgets: ungrouped }]
+      : labelled;
+  });
 
   onDragStart(event: DragEvent, widget: WidgetDisplayItem) {
     if (!event.dataTransfer) return;

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
@@ -16,6 +16,10 @@ import { DashboardBridgeService } from '../services/dashboard-bridge.service';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 
 interface WidgetDisplayItem extends WidgetMetadata {
   safeSvgIcon?: SafeHtml;
@@ -39,6 +43,10 @@ interface WidgetListGroup {
     MatTooltipModule,
     MatExpansionModule,
     MatDividerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './widget-list.component.html',
@@ -52,6 +60,7 @@ export class WidgetListComponent {
 
   // Input to track collapsed state for tooltip display
   collapsed = input<boolean>(false);
+  enableSearchBox = input<boolean>(false);
 
   /**
    * Labels of the groups the user has collapsed. Groups start expanded, and the
@@ -62,15 +71,52 @@ export class WidgetListComponent {
 
   activeWidget = signal<string | null>(null);
 
+  /**
+   * Free-text filter over the list. Empty (or whitespace only) means no
+   * filtering. Kept per component instance, like the collapsed group state.
+   */
+  readonly searchTerm = signal('');
+
+  readonly #normalizedSearchTerm = computed(() =>
+    this.enableSearchBox() ? this.searchTerm().trim().toLowerCase() : ''
+  );
+
+  /** Whether a filter is currently narrowing the list. */
+  readonly isFiltering = computed(
+    () => this.#normalizedSearchTerm().length > 0
+  );
+
+  /** Whether the search box is rendered: the icon-only rail has no room. */
+  readonly showSearchBox = computed(
+    () => this.enableSearchBox() && !this.collapsed()
+  );
+
   // Get grid cell dimensions from bridge service (uses first available dashboard)
   gridCellDimensions = this.#bridge.availableDimensions;
 
-  widgets = computed(() =>
+  readonly #allWidgets = computed(() =>
     this.#service.widgetTypes().map((w) => ({
       ...w.metadata,
       safeSvgIcon: this.#sanitizer.bypassSecurityTrustHtml(w.metadata.svgIcon),
     }))
   );
+
+  /**
+   * The widgets the list renders: every registered widget, or those matching
+   * `searchTerm`. A widget matches when the term is contained in its name,
+   * description or widget type id — the type id so a user who knows what they
+   * registered can search by it directly. Matching is case insensitive.
+   */
+  widgets = computed(() => {
+    const term = this.#normalizedSearchTerm();
+    if (!term) return this.#allWidgets();
+
+    return this.#allWidgets().filter((widget) =>
+      [widget.name, widget.description, widget.widgetTypeid].some((field) =>
+        field?.toLowerCase().includes(term)
+      )
+    );
+  });
 
   /**
    * Widgets bucketed by `WidgetMetadata.group`. Groups keep the order in which
@@ -111,6 +157,8 @@ export class WidgetListComponent {
    * toggle, so they are always shown.
    */
   isGroupExpanded(label?: string): boolean {
+    // While filtering, a collapsed group would hide its own matches.
+    if (this.isFiltering()) return true;
     return !label || !this.#collapsedGroups().has(label);
   }
 
@@ -125,7 +173,9 @@ export class WidgetListComponent {
    * the expansion panel's `opened`/`closed` outputs.
    */
   setGroupExpanded(label: string | undefined, expanded: boolean): void {
-    if (!label) return;
+    // Filtering force-expands every group, so the panels' own open/close
+    // outputs would otherwise overwrite what the user collapsed before.
+    if (!label || this.isFiltering()) return;
 
     this.#collapsedGroups.update((collapsed) => {
       if (collapsed.has(label) === !expanded) return collapsed;
@@ -138,6 +188,15 @@ export class WidgetListComponent {
       }
       return next;
     });
+  }
+
+  /** Clears the filter, restoring the full list. */
+  clearSearch(): void {
+    this.searchTerm.set('');
+  }
+
+  onSearchInput(value: string): void {
+    this.searchTerm.set(value);
   }
 
   onDragStart(event: DragEvent, widget: WidgetDisplayItem) {

--- a/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
+++ b/projects/ngx-dashboard/src/lib/widget-list/widget-list.component.ts
@@ -20,6 +20,12 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSliderModule } from '@angular/material/slider';
+import {
+  formatGutterSize,
+  GUTTER_UNITS,
+  parseGutterSize,
+} from './gutter-size';
 
 interface WidgetDisplayItem extends WidgetMetadata {
   safeSvgIcon?: SafeHtml;
@@ -47,6 +53,7 @@ interface WidgetListGroup {
     MatInputModule,
     MatIconModule,
     MatButtonModule,
+    MatSliderModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './widget-list.component.html',
@@ -61,6 +68,12 @@ export class WidgetListComponent {
   // Input to track collapsed state for tooltip display
   collapsed = input<boolean>(false);
   enableSearchBox = input<boolean>(false);
+
+  /**
+   * Shows a slider docked to the list's bottom-left corner that drives the
+   * dashboard's gutter size live.
+   */
+  enableGutterSlider = input<boolean>(false);
 
   /**
    * Labels of the groups the user has collapsed. Groups start expanded, and the
@@ -90,6 +103,32 @@ export class WidgetListComponent {
   readonly showSearchBox = computed(
     () => this.enableSearchBox() && !this.collapsed()
   );
+
+  /**
+   * Whether the gutter slider is rendered. Like the search box it needs more
+   * room than the icon-only rail has. It also needs a dashboard to drive: the
+   * bridge has nothing to write to until one registers.
+   */
+  readonly showGutterSlider = computed(
+    () =>
+      this.enableGutterSlider() &&
+      !this.collapsed() &&
+      this.#bridge.hasDashboards()
+  );
+
+  /**
+   * The dashboard's gutter, split for the slider. Derived from the store rather
+   * than held locally, so the slider tracks a gutter changed elsewhere (an
+   * import, say) instead of drifting from it.
+   */
+  readonly gutter = computed(() => parseGutterSize(this.#bridge.gutterSize()));
+
+  /** Slider bounds follow the unit the dashboard already authored its gutter in. */
+  readonly gutterMax = computed(() => GUTTER_UNITS[this.gutter().unit].max);
+  readonly gutterStep = computed(() => GUTTER_UNITS[this.gutter().unit].step);
+
+  /** The gutter as CSS, for the slider's readout. */
+  readonly gutterLabel = computed(() => formatGutterSize(this.gutter()));
 
   // Get grid cell dimensions from bridge service (uses first available dashboard)
   gridCellDimensions = this.#bridge.availableDimensions;
@@ -197,6 +236,19 @@ export class WidgetListComponent {
 
   onSearchInput(value: string): void {
     this.searchTerm.set(value);
+  }
+
+  /**
+   * Writes the slider's value straight through to the dashboard — a gutter is a
+   * visual measure, so it is set by watching the grid reflow, not by committing
+   * a number chosen blind. The unit is the dashboard's own; only the magnitude
+   * is the slider's to change.
+   */
+  onGutterInput(value: number): void {
+    if (Number.isNaN(value)) return;
+    this.#bridge.setGutterSize(
+      formatGutterSize({ value, unit: this.gutter().unit })
+    );
   }
 
   onDragStart(event: DragEvent, widget: WidgetDisplayItem) {


### PR DESCRIPTION
Adds an optional group to WidgetMetadata so the widget list can be organised into collapsible sections instead of one long flat list. Purely additive — widgets that declare no group render exactly as before


Example image

<img width="304" height="600" alt="image" src="https://github.com/user-attachments/assets/a5941628-a07d-4512-b005-a4b47875e712" />
<img width="130" height="559" alt="image" src="https://github.com/user-attachments/assets/de86b36e-868e-4bca-b112-0a09aac748ac" />


